### PR TITLE
Add Agent-OS standards and configuration

### DIFF
--- a/agent-os/standards/books/book-map-conventions.md
+++ b/agent-os/standards/books/book-map-conventions.md
@@ -1,0 +1,33 @@
+---
+name: Book Map Conventions
+description: BOOK_MAP key casing rules, abbreviation source, and alternative name pattern
+type: project
+---
+
+# Book Map Conventions
+
+`BOOK_MAP` in `src/books.ts` maps book names to abbreviations used in Obsidian wiki-links.
+
+## Key rules
+
+- All keys are **lowercase** — `lookupBook()` calls `.toLowerCase()` before lookup
+- Never add a mixed-case key; lookups will silently fail
+
+```typescript
+// Correct
+"1 samuel": { abbrev: "1 Sam", singleChapter: false }
+
+// Wrong — will never match
+"1 Samuel": { abbrev: "1 Sam", singleChapter: false }
+```
+
+## Abbreviation values
+
+The `abbrev` field must match the **actual note filenames in the Obsidian vault**.
+Changing an abbrev breaks existing wiki-links. Verify vault filenames before editing.
+
+## Alternative names
+
+Multiple keys can share the same `abbrev` (e.g. `"sirach"`, `"ecclesiasticus"`,
+`"wisdom of ben sira"` all map to `{ abbrev: "Sir" }`). Use this for books
+with variant names.

--- a/agent-os/standards/books/single-chapter-books.md
+++ b/agent-os/standards/books/single-chapter-books.md
@@ -1,0 +1,31 @@
+---
+name: Single-Chapter Books
+description: Why singleChapter:true books use [[Abbrev#vN]] instead of [[Abbrev-01#vN]]
+type: project
+---
+
+# Single-Chapter Books
+
+Five books have only one chapter: **Obadiah, Philemon, 2 John, 3 John, Jude**.
+These are flagged with `singleChapter: true` in `BOOK_MAP`.
+
+## Obsidian link format difference
+
+| Book type | Format | Example |
+|-----------|--------|---------|
+| Multi-chapter | `[[Abbrev-{chapter2}#vN]]` | `[[Matt-05#v3]]` |
+| Single-chapter | `[[Abbrev#vN]]` | `[[Obad#v3]]` |
+
+The vault note for single-chapter books is named without a chapter number
+(e.g. `Obad.md`, not `Obad-01.md`). Including a chapter would produce a broken link.
+
+## Logic in obsidianLink()
+
+```typescript
+if (singleChapter) {
+  return `[[${abbrev}#v${verse}]]`;  // no chapter number
+}
+```
+
+When adding a new single-chapter book, set `singleChapter: true` and verify
+the Obsidian vault note filename has no chapter suffix.

--- a/agent-os/standards/config/obsidian-links-opt-out.md
+++ b/agent-os/standards/config/obsidian-links-opt-out.md
@@ -1,0 +1,21 @@
+---
+name: Obsidian Links Opt-Out
+description: INCLUDE_OBSIDIAN_LINKS is enabled by default; only the string 'false' disables it
+type: project
+---
+
+# Obsidian Links Opt-Out
+
+Obsidian wiki-links are **enabled by default**. The primary use case is Obsidian vaults;
+you must explicitly disable them.
+
+```typescript
+// src/config.ts
+includeObsidianLinks: process.env.INCLUDE_OBSIDIAN_LINKS !== "false"
+```
+
+- Only the string `"false"` disables Obsidian links
+- Missing env var, `"true"`, `"1"`, `"yes"` — all produce `true`
+- Do not change this to opt-in (`=== "true"`) without updating docs and tests
+
+To disable: set `INCLUDE_OBSIDIAN_LINKS=false` in the server's environment.

--- a/agent-os/standards/config/startup-config-loading.md
+++ b/agent-os/standards/config/startup-config-loading.md
@@ -1,0 +1,22 @@
+---
+name: Startup Config Loading
+description: Config is loaded once at module init; env var changes require a server restart
+type: project
+---
+
+# Startup Config Loading
+
+`loadConfig()` is called once at module initialization in `enrichment.ts`:
+
+```typescript
+// src/enrichment.ts
+const config = loadConfig();  // runs once on import
+```
+
+- Env vars (`BIBLE_VERSION`, `OBSIDIAN_FORMAT`, `INCLUDE_OBSIDIAN_LINKS`) are read at server startup
+- Changes to env vars after startup have no effect — **restart the server to reconfigure**
+- This is intentional: MCP servers are long-lived processes configured at launch
+
+**Testing implication:** Setting `process.env` in tests does not affect the cached
+`config` object. Config-sensitive tests must either mock `loadConfig` or accept
+the startup value.

--- a/agent-os/standards/enrichment/double-link-prevention.md
+++ b/agent-os/standards/enrichment/double-link-prevention.md
@@ -1,0 +1,22 @@
+---
+name: Double-Link Prevention
+description: Regex guards that prevent re-enriching already-linked text and ensure idempotency
+type: project
+---
+
+# Double-Link Prevention
+
+`BIBLE_REF_RE` and `CCC_RE` use negative lookbehind/lookahead to skip text
+already inside a markdown link.
+
+```
+(?<![\[\(])     — not preceded by [ or (
+(?![^\[]*\]\()  — not followed by ](
+```
+
+**Guarantees two things:**
+1. **Idempotency** — running `enrichMarkdown()` on already-enriched output produces no change
+2. **Hand-authored link preservation** — existing `[text](url)` links are never re-wrapped
+
+When adding new regex patterns, include these same guards.
+Test idempotency: `enrichMarkdown(enrichMarkdown(input)) === enrichMarkdown(input)`

--- a/agent-os/standards/enrichment/implicit-chapter-inheritance.md
+++ b/agent-os/standards/enrichment/implicit-chapter-inheritance.md
@@ -1,0 +1,20 @@
+---
+name: Implicit Chapter Inheritance
+description: How parseChapterVerse() propagates chapter numbers across comma-separated verse groups
+type: project
+---
+
+# Implicit Chapter Inheritance
+
+`parseChapterVerse()` tracks `lastChapter` across comma-separated parts.
+A bare verse or range (no `chapter:`) inherits the previous chapter.
+
+```
+"16:1, 4-13"   → ch16:v1 , ch16:v4-13
+"23:1, 4, 6"   → ch23:v1 , ch23:v4 , ch23:v6
+"2:1, 3:5"     → ch2:v1 , ch3:v5
+```
+
+- Chapter state resets for each new top-level regex match (not shared across references)
+- Always applied — no exceptions or opt-out
+- Separator is comma; dash means verse range within a chapter

--- a/agent-os/standards/enrichment/three-pass-ordering.md
+++ b/agent-os/standards/enrichment/three-pass-ordering.md
@@ -1,0 +1,18 @@
+---
+name: Three-Pass Enrichment Ordering
+description: The strict pass order in enrichMarkdown() and why it must not change
+type: project
+---
+
+# Three-Pass Enrichment Ordering
+
+The `enrichMarkdown()` function runs three passes in strict order:
+
+1. **Backtick-wrapped refs** — e.g. `` `1 Samuel 16:1:` `` unwrapped and enriched
+2. **Plain-text Bible refs** — matches running text not already inside `[]()`
+3. **CCC refs** — matches `CCC ###` not already inside `[]`
+
+**Never reorder the passes.**
+
+- Backticks must go first: after pass 2 adds `[text](url)` markdown, backtick patterns could partially overlap the generated link syntax
+- CCC must go last: generated Bible Gateway URLs contain digit sequences that could be matched as CCC paragraph numbers

--- a/agent-os/standards/global/coupling-cohesion.md
+++ b/agent-os/standards/global/coupling-cohesion.md
@@ -1,0 +1,188 @@
+# Coupling and Cohesion
+
+Low coupling and high cohesion are the two foundational measures of modular design quality. They were formalised by Larry Constantine in the 1960s and remain the most reliable indicators of whether a codebase will be easy or painful to change.
+
+**Coupling** is the degree to which one module depends on another. Lower is better.
+**Cohesion** is the degree to which the elements inside a module belong together. Higher is better.
+
+A well-designed module does one thing well (high cohesion) and needs as little as possible from the outside world to do it (low coupling). These two properties reinforce each other: a module that does one thing tends to need fewer external dependencies; a module with few dependencies tends to have a clear, unified purpose.
+
+---
+
+## The Prime Directive: Minimise Dependencies
+
+### Rules
+
+- Every dependency is a liability. It must be imported, initialised, versioned, tested, and updated. Add a dependency only when the alternative is clearly worse.
+- Depend on the narrowest interface that satisfies your need. If you need `send(message)`, depend on a `Sender` interface with one method — not on a full messaging SDK with fifty.
+- Depend in the direction of stability. A frequently-changing module must not depend on another frequently-changing module. If both change, they will break each other.
+- Prefer receiving dependencies over fetching them. A module that accepts collaborators as parameters can be used in any context. A module that imports them directly is bound to that specific implementation.
+- Question every import. Before adding a dependency to a module, ask: can this responsibility be pushed to the caller, or handled at a boundary instead?
+
+### Example
+
+```
+WRONG — module fetches its own dependencies, depends on three concrete things:
+  import DatabaseClient from 'database-sdk'
+  import EmailProvider from 'email-sdk'
+  import Logger from 'logging-sdk'
+
+  function registerUser(data):
+    db = new DatabaseClient(env.DB_URL)
+    email = new EmailProvider(env.EMAIL_KEY)
+    log = new Logger()
+    ...
+
+RIGHT — module accepts what it needs, depends on narrow interfaces:
+  function registerUser(data, repo: UserRepository, notifier: Notifier, log: Logger)
+    # three narrow interfaces, each with 1-2 methods
+    # caller decides what implementations to provide
+```
+
+---
+
+## Coupling Types — Worst to Best
+
+Understanding the type of coupling helps identify how to reduce it. Listed from most harmful to least:
+
+| Level | Name | Description | How to fix |
+|-------|------|-------------|------------|
+| 1 | **Content coupling** | Module A directly modifies the internal data of module B | Enforce encapsulation; expose behaviour, not data |
+| 2 | **Common coupling** | Two modules share mutable global state | Eliminate globals; pass state explicitly |
+| 3 | **Control coupling** | A passes a flag to B that controls B's internal logic | Split B into two functions; let A call the right one |
+| 4 | **Stamp coupling** | A passes a large data structure to B; B uses only part of it | Pass only what B needs; introduce a narrow type |
+| 5 | **Data coupling** | A passes only the data B needs, as simple parameters | Acceptable — keep parameters minimal |
+| 6 | **Message coupling** | A and B communicate only through well-defined message/event interfaces | Ideal for independent modules |
+
+### Example — Control Coupling
+
+```
+WRONG — flag controls internal branching (control coupling):
+  function sendNotification(user, message, isUrgent: boolean):
+    if isUrgent:
+      sms.send(user.phone, message)
+    else:
+      email.send(user.email, message)
+
+RIGHT — two functions, caller decides:
+  function sendSmsNotification(user, message)
+  function sendEmailNotification(user, message)
+```
+
+### Example — Stamp Coupling
+
+```
+WRONG — entire Order passed to a function that only needs the total (stamp coupling):
+  function calculateTax(order: Order):
+    return order.total * TAX_RATE
+
+RIGHT — pass only what is needed (data coupling):
+  function calculateTax(orderTotal: Money):
+    return orderTotal * TAX_RATE
+```
+
+---
+
+## Cohesion Types — Best to Worst
+
+High cohesion means the elements in a module genuinely belong together. Listed from most to least cohesive:
+
+| Level | Name | Description |
+|-------|------|-------------|
+| 1 | **Functional** | Every element contributes to a single, well-defined task |
+| 2 | **Sequential** | Output of one element feeds the next (pipeline) |
+| 3 | **Communicational** | Elements operate on the same data |
+| 4 | **Procedural** | Elements follow a sequence but are otherwise unrelated |
+| 5 | **Temporal** | Elements are grouped because they happen at the same time (e.g. startup) |
+| 6 | **Logical** | Elements are grouped by category but do unrelated things (e.g. a "utils" module) |
+| 7 | **Coincidental** | Elements have no meaningful relationship |
+
+Aim for functional or sequential cohesion. Logical and coincidental cohesion are signals to split the module.
+
+```
+LOW COHESION — "utils" module does unrelated things:
+  utils.formatDate(date)
+  utils.validateEmail(email)
+  utils.hashPassword(pwd)
+  utils.parseCsv(file)
+  utils.sendSlack(msg)
+
+HIGH COHESION — each module does one thing:
+  DateFormatter.format(date)
+  EmailValidator.validate(email)
+  PasswordHasher.hash(pwd)
+```
+
+---
+
+## Stable Dependencies Principle
+
+Depend in the direction of stability. A module that changes frequently must not depend on another module that also changes frequently.
+
+### Rules
+
+- Stable modules (interfaces, domain models, utility functions) should be depended on freely — they rarely change.
+- Unstable modules (HTTP handlers, UI components, adapters) should not be depended on by stable modules.
+- If a stable module must use an unstable one, introduce an interface between them so the stable module depends on the interface (stable), not the implementation (unstable).
+- Ports in hexagonal architecture are stable by design — they change only when the domain changes.
+
+### Example
+
+```
+WRONG — stable domain logic depends on unstable infrastructure:
+  OrderService (stable) → PostgresRepository (unstable — DB schema changes)
+
+RIGHT — stable domain logic depends on a stable interface:
+  OrderService (stable) → OrderRepository interface (stable)
+                               ↑
+                    PostgresRepository (unstable)
+```
+
+---
+
+## Acyclic Dependencies Principle
+
+The dependency graph must contain no cycles.
+
+### Rules
+
+- A cycle means two modules are so entangled that neither can be changed, tested, or released independently of the other.
+- If module A depends on B and B depends on A, extract the shared concern into a third module C that both depend on.
+- Run a dependency cycle check in CI for large codebases.
+- Cycles in package/module imports are always a design problem — resolve the design rather than using workarounds like deferred imports.
+
+### Example
+
+```
+CYCLE — neither can change without breaking the other:
+  UserService → OrderService → UserService
+
+FIX — extract the shared concept both need:
+  UserService   →  AccountSummary (interface/type)
+  OrderService  →  AccountSummary (interface/type)
+
+  Neither UserService nor OrderService knows about the other.
+```
+
+---
+
+## Dependency Budget
+
+Treat dependencies as a budget, not a free resource.
+
+### Rules
+
+- For any module, count its direct imports/dependencies. If the count exceeds five to seven, the module likely has more than one responsibility.
+- Each new package-level dependency (an npm package, a pip package, an imported library) adds a supply-chain risk, a versioning constraint, and a build-time cost. Justify it explicitly.
+- Prefer using language built-ins and standard library before reaching for a third-party package.
+- When evaluating a new package dependency, ask: is the value this provides worth the maintenance cost over the next two years?
+
+---
+
+## Related Documents
+
+- `global/solid.md` — Interface Segregation Principle (I) enforces narrow interfaces; Dependency Inversion Principle (D) enforces depending on abstractions
+- `global/hexagonal-architecture.md` — ports and adapters enforce the Stable Dependencies Principle structurally; orthogonal design is low coupling applied to component boundaries
+- `global/dry.md` — knowledge duplication creates implicit coupling; the single authoritative representation reduces it
+- `global/simplicity.md` — YAGNI prevents unnecessary dependencies from being added in the first place
+- `global/object-interaction.md` — Law of Demeter is the method-level expression of low coupling

--- a/agent-os/standards/global/delegation.md
+++ b/agent-os/standards/global/delegation.md
@@ -1,0 +1,127 @@
+# Delegation
+
+Delegation is the practice of an object handling a request by passing it to a second "delegate" object rather than doing the work itself. The delegating object remains responsible for the outcome — it coordinates and composes; the delegate executes.
+
+---
+
+## Delegation vs Inheritance
+
+Inheritance and delegation are two different answers to the same question: how does an object gain a capability?
+
+- **Inheritance** says "I *am* a X" — the subclass acquires the capability by being a specialisation of the base class.
+- **Delegation** says "I *have* a X that does this for me" — the object acquires the capability by holding a reference to a collaborator and forwarding the relevant calls.
+
+Prefer delegation when the relationship is not a genuine "is-a" relationship, when you want to swap the capability at runtime, or when combining multiple capabilities would require an impractical inheritance hierarchy.
+
+```
+INHERITANCE — capability comes from being a subtype:
+  class LoggingRepository extends PostgresRepository
+    ← now tightly coupled to the parent implementation
+
+DELEGATION — capability comes from forwarding to a collaborator:
+  class LoggingRepository
+    constructor(inner: Repository)
+    save(entity) → inner.save(entity)   ← forwards, adds logging around it
+    ← works with any Repository, not just Postgres
+```
+
+---
+
+## Rules
+
+- **Delegate to injected collaborators, never to internally constructed ones.** If the delegate is `new`-ed inside the delegating object, it cannot be replaced — this breaks testability and couples the two classes. Pass the delegate in via the constructor. This rule pairs directly with the Dependency Inversion Principle and the dependency injection pattern.
+- **The delegating object remains responsible for the outcome.** Delegation is not abandonment. The delegator coordinates the interaction: it decides when to call the delegate, what to pass, and how to handle the result. The delegate executes one specific part of the work.
+- **Delegate along port interfaces, not to concrete classes.** The delegating object should depend on an abstraction (an interface or protocol) rather than the concrete class of the delegate. This preserves substitutability and testability.
+- **Use delegation to add capabilities without subclassing.** Logging, caching, retrying, auditing, and rate-limiting are all cross-cutting concerns that can be added by wrapping a delegate, not by extending a class. This keeps the base implementation clean and the added behaviour composable.
+- **Explicit delegation (forwarding calls) is clearer than implicit delegation (inheritance).** When you forward a call explicitly, the intent is visible in the code. When you rely on inherited methods to do the work, the path of execution is hidden in the class hierarchy.
+
+---
+
+## Delegation vs Composition
+
+These terms are related but distinct:
+
+- **Composition** is the structural relationship: an object *has* a collaborator as a field.
+- **Delegation** is the behavioural act: an object *forwards* a call to that collaborator.
+
+Composition is necessary for delegation, but not sufficient. An object may hold a reference to a collaborator and never delegate to it (using it only as a data store, for example). Delegation is the active, runtime use of the composed relationship.
+
+They are complementary: compose your objects structurally, then implement behaviour via delegation to those composed parts.
+
+---
+
+## Examples
+
+### Logger delegating to a Transport
+
+```
+interface Transport:
+  write(level, message, metadata)
+
+class Logger:
+  constructor(transport: Transport)
+
+  info(message, metadata):
+    self.transport.write('info', message, metadata)
+
+  error(message, metadata):
+    self.transport.write('error', message, metadata)
+
+ConsoleTransport  implements Transport
+FileTransport     implements Transport
+RemoteTransport   implements Transport
+
+Logger delegates the act of writing to whichever Transport was injected.
+Swapping the transport (e.g. in tests) does not require changing Logger.
+```
+
+### Repository delegating reads to a cache, writes to a database
+
+```
+interface ProductRepository:
+  findById(id) → Product | null
+  save(product) → Product
+
+class CachingProductRepository implements ProductRepository:
+  constructor(
+    cache:    CachePort,
+    database: ProductRepository,
+  )
+
+  findById(id):
+    cached = cache.get('product:' + id)
+    if cached: return cached
+    product = database.findById(id)     ← delegate reads to database
+    if product: cache.set('product:' + id, product)
+    return product
+
+  save(product):
+    result = database.save(product)     ← delegate writes to database
+    cache.delete('product:' + result.id)
+    return result
+
+Neither the cache nor the database knows about each other.
+CachingProductRepository orchestrates; both delegates execute their part.
+```
+
+---
+
+## Delegation Enables Decorator, Proxy, and Facade
+
+All three GoF structural patterns are specialised forms of delegation:
+
+| Pattern | How it uses delegation |
+|---------|----------------------|
+| **Decorator** | Wraps a delegate implementing the same interface; adds behaviour before or after forwarding the call |
+| **Proxy** | Wraps a delegate implementing the same interface; controls access, defers initialisation, or intercepts the call |
+| **Facade** | Holds references to multiple delegates (subsystem components); composes them into a simpler interface for callers |
+
+The difference is in intent: Decorator adds behaviour, Proxy controls access or defers work, and Facade simplifies a complex subsystem. The mechanical form — hold a reference to a collaborator and forward calls — is the same in all three cases.
+
+---
+
+## Related Documents
+
+- `global/hexagonal-architecture.md` — ports are the interfaces along which delegation flows; adapters are delegates injected at the boundary
+- `global/gang-of-four.md` — Decorator, Proxy, and Facade sections show delegation in three different structural forms
+- `global/solid.md` — the Dependency Inversion Principle (DIP) explains why delegates must be injected via interfaces; the Single Responsibility Principle (SRP) explains why the delegating object keeps coordination responsibility while the delegate keeps execution responsibility

--- a/agent-os/standards/global/dry.md
+++ b/agent-os/standards/global/dry.md
@@ -1,0 +1,157 @@
+# DRY — Don't Repeat Yourself
+
+> "Every piece of knowledge must have a single, unambiguous, authoritative representation within a system."
+> — The Pragmatic Programmer, Hunt & Thomas
+
+DRY is about knowledge, not text. Two pieces of code that look similar are not necessarily a DRY violation. Two pieces of code that encode the *same rule or decision* are — because when that rule changes, both must change, and one will be missed.
+
+---
+
+## The Core Principle
+
+### Rules
+
+- Identify the underlying knowledge or decision being expressed, not just the surface-level syntax.
+- If the same business rule, algorithm, or constraint exists in two places, one of them will eventually fall out of sync.
+- The authoritative representation should be the only place that knows the rule — all other places derive from it.
+- Duplication of structure (similar-looking code) is often fine. Duplication of knowledge (the same decision encoded twice) is what causes bugs.
+
+### Example
+
+```
+DUPLICATION OF KNOWLEDGE — the VAT rate is encoded in three places:
+  calculatePrice(net):     return net * 1.20
+  formatReceipt(net):      vat = net * 0.20
+  validateInvoice(gross):  if gross != net * 1.20: raise Error
+
+When VAT changes, all three must be updated. One will be missed.
+
+SINGLE AUTHORITATIVE SOURCE:
+  VAT_RATE = 0.20
+
+  calculatePrice(net):     return net * (1 + VAT_RATE)
+  formatReceipt(net):      vat = net * VAT_RATE
+  validateInvoice(gross):  if gross != net * (1 + VAT_RATE): raise Error
+```
+
+---
+
+## What DRY Is Not
+
+DRY is frequently misapplied as "never write similar-looking code twice." This produces premature abstractions that are harder to understand and change than the duplication they replaced.
+
+### Rules
+
+- Do not abstract two pieces of code just because they look the same today. Ask: do they represent the same knowledge, or do they merely look similar?
+- Accidental similarity is not duplication. Two modules that happen to use the same formula for different business reasons should stay separate — they will diverge.
+- The **Rule of Three**: tolerate one instance of duplication. Abstract at the second repetition only if the knowledge is genuinely shared.
+- Premature abstraction is more expensive than duplication. A bad abstraction is harder to remove than duplicated code.
+
+### Example
+
+```
+ACCIDENTAL SIMILARITY — do not abstract:
+  calculateShippingCost(weight):  return weight * 2.5
+  calculateTaxAmount(value):      return value * 2.5
+
+These look identical but represent unrelated rules. They will diverge.
+Abstracting them creates a meaningless coupling.
+
+GENUINE DUPLICATION — abstract:
+  function discountForGold(price):   return price * 0.10
+  function discountForSilver(price): return price * 0.10
+
+Same rule, same knowledge. Extract to discountForLoyaltyTier(price, rate).
+```
+
+---
+
+## AHA — Avoid Hasty Abstractions
+
+Coined by Kent C. Dodds as a complement to DRY. Prefer duplication over the wrong abstraction.
+
+### Rules
+
+- Write the code inline first. Abstract only when the pattern is clear and the abstraction has a name that carries meaning.
+- If you cannot name the abstraction without using "util", "helper", "manager", or "and", it is not ready to be extracted.
+- A wrong abstraction forces all future callers to work around it with special cases, flags, and conditional parameters — this is worse than duplication.
+- Inline the wrong abstraction and start again when you understand the pattern.
+
+### Example
+
+```
+WRONG — abstraction with a flag to handle two different cases:
+  function renderButton(label, isPrimary, hasIcon, iconPosition, ...):
+    ...  ← grows a new parameter for every caller's special case
+
+RIGHT — two clear, separate components until the real pattern emerges:
+  renderPrimaryButton(label)
+  renderIconButton(label, icon)
+
+  Abstract later if a genuine shared structure becomes clear.
+```
+
+---
+
+## DRY in Tests
+
+Test code has different duplication trade-offs from production code.
+
+### Rules
+
+- Duplication in test *setup* is worth abstracting into fixtures or factories — it reduces the cost of changing the interface under test.
+- Duplication in test *assertions* is often intentional — each test should be independently readable without needing to trace through shared helpers.
+- Do not abstract test assertions into shared helpers. If a test fails, the failure should be understandable by reading that test alone.
+- Test names and descriptions must never be shared or generated — each test must state its own intent.
+- Prefer explicit, slightly repetitive test bodies over clever abstractions that obscure what is being tested.
+
+### Example
+
+```
+GOOD — extract shared setup, keep assertions explicit:
+  user = create_test_user(role='admin')   ← factory, not duplicated construction
+
+  test_admin_can_delete_post:
+    result = delete_post(user, post)
+    assert result.status == 'deleted'     ← assertion stays local and explicit
+
+  test_admin_can_archive_post:
+    result = archive_post(user, post)
+    assert result.status == 'archived'    ← assertion stays local and explicit
+
+BAD — shared assertion helper obscures intent:
+  def assert_post_action_succeeded(result):
+    assert result.status in ('deleted', 'archived')
+
+  test_admin_can_delete_post:
+    assert_post_action_succeeded(delete_post(user, post))
+    ← failure message is now: "status not in ('deleted', 'archived')"
+    ← which post action? what was expected? must read helper to find out
+```
+
+---
+
+## DRY and Single Responsibility
+
+These principles reinforce each other. If knowledge is split across multiple modules, it is both a DRY violation and a SRP violation — more than one module now has reason to change when that knowledge changes. The fix is the same: find the single authoritative place where that knowledge should live and make all other places derive from it.
+
+---
+
+## Summary
+
+| Situation | Guidance |
+|-----------|----------|
+| Same business rule in two places | Extract to a single authoritative source |
+| Similar-looking code, different meaning | Leave separate — they will diverge |
+| Second occurrence of the same pattern | Consider abstracting |
+| Abstraction requires flags or special cases | Inline it and wait for the real pattern |
+| Duplicated test setup | Extract to fixtures/factories |
+| Duplicated test assertions | Keep explicit — readability matters more |
+
+---
+
+## Related Documents
+
+- `global/solid.md` — SRP and DRY reinforce each other: a single-responsibility module naturally has one authoritative place for each piece of knowledge
+- `global/hexagonal-architecture.md` — a single port definition is the authoritative source for a boundary contract; duplicating it across adapters is a DRY violation
+- `global/gang-of-four.md` — Factory Method and Builder centralise object-creation knowledge, eliminating construction duplication across callers

--- a/agent-os/standards/global/gang-of-four.md
+++ b/agent-os/standards/global/gang-of-four.md
@@ -1,0 +1,427 @@
+# Gang of Four Design Patterns
+
+The Gang of Four (GoF) patterns, from *Design Patterns: Elements of Reusable Object-Oriented Software* (Gamma, Helm, Johnson, Vlissides), are 23 solutions to recurring design problems. They are a vocabulary, not a checklist — use them when the problem they solve is actually present, not to demonstrate familiarity with patterns.
+
+This document covers the patterns most relevant to application architecture, testability, and everyday design decisions. For each pattern, the emphasis is on *when to use it* and *what problem it solves*, not just *what it looks like*.
+
+Patterns are grouped into three categories: **Creational** (how objects are made), **Structural** (how objects are composed), and **Behavioral** (how objects communicate).
+
+---
+
+## Creational Patterns
+
+### Factory Method
+
+Define an interface for creating an object, but let subclasses or callers decide which class to instantiate.
+
+**Use when** the exact type of object to create is determined at runtime, or when you want to decouple object creation from the code that uses the object.
+
+**Testability**: Replace the factory in tests to control what gets created without subclassing the class under test.
+
+```
+interface Notifier:
+  send(message)
+
+EmailNotifier implements Notifier
+SmsNotifier   implements Notifier
+
+function createNotifier(type) → Notifier:
+  if type == 'email': return EmailNotifier()
+  if type == 'sms':   return SmsNotifier()
+
+In tests: inject a FakeNotifier directly — bypass the factory entirely.
+```
+
+---
+
+### Abstract Factory
+
+Provide an interface for creating families of related objects without specifying their concrete classes.
+
+**Use when** a system must be independent of how its objects are created, and you need to enforce that a group of related objects are used together (e.g. a UI theme that must use matching Button, Input, and Dialog).
+
+**Testability**: Swap the entire factory for a test factory that returns fakes. All collaborators are consistently replaced in one place.
+
+```
+interface UiFactory:
+  createButton() → Button
+  createDialog() → Dialog
+
+LightThemeFactory implements UiFactory
+DarkThemeFactory  implements UiFactory
+TestUiFactory     implements UiFactory   ← returns fakes
+
+Application receives UiFactory — never knows which theme it uses.
+```
+
+---
+
+### Builder
+
+Separate the construction of a complex object from its representation.
+
+**Use when** an object has many optional parts, requires a specific construction order, or construction logic is complex enough that it should not live in the object itself.
+
+**Testability**: Builders make test data construction readable and maintainable. Test builder factories are a standard pattern for creating rich domain objects in tests without long constructor calls.
+
+```
+order = OrderBuilder()
+  .withCustomer(customer)
+  .withItem(product, quantity=2)
+  .withDiscount(10)
+  .build()
+```
+
+---
+
+### Singleton
+
+Ensure a class has only one instance and provide global access to it.
+
+**Use sparingly.** Singletons introduce global state, make tests order-dependent, and make it impossible to run tests in parallel without interference. In most cases, dependency injection achieves the same goal without the drawbacks.
+
+**Prefer**: inject a shared instance through the dependency graph rather than using a static `getInstance()` method.
+
+```
+AVOID:
+  config = Config.getInstance()   ← global, hidden dependency, test-hostile
+
+PREFER:
+  class AppConfig: ...
+  config = AppConfig(env)
+  service = MyService(config)     ← injected, replaceable in tests
+```
+
+---
+
+### Flyweight
+
+Share fine-grained objects to support large numbers of instances efficiently.
+
+**Use when** a large number of objects consume too much memory because they store repeated, shared data. Factor out the intrinsic (shared, immutable) state into a flyweight object; keep extrinsic (context-specific) state outside.
+
+**Intrinsic state**: shared, immutable data stored in the flyweight (e.g. a font's character shape data).
+**Extrinsic state**: context-specific data passed to the flyweight at use time (e.g. a character's position on screen).
+
+**Common uses**: compiled regex patterns (shared across calls), parsed configuration objects, database connection metadata, template objects.
+
+**Testability**: flyweights are small, immutable, and stateless — trivially testable. Pass extrinsic state as parameters.
+
+```
+WITHOUT flyweight:
+  10,000 Character objects, each storing: shape_data(50kb) + position + colour
+  = 500MB
+
+WITH flyweight:
+  26 CharacterType flyweights, each storing: shape_data(50kb)
+  10,000 CharacterInstance objects, each storing: flyweight_ref + position + colour
+  = 1.3MB + trivial instance data
+```
+
+---
+
+## Structural Patterns
+
+### Adapter
+
+Convert the interface of a class into another interface that clients expect.
+
+**Use when** you need to integrate a third-party or legacy component whose interface does not match what your application expects.
+
+**This is the pattern behind hexagonal architecture**. Adapters implement port interfaces, translating between the application's domain language and an external system's API. See `global/hexagonal-architecture.md`.
+
+```
+interface EmailSender:         ← port defined by the application core
+  send(to, subject, body)
+
+SendGridAdapter implements EmailSender:
+  send(to, subject, body):
+    self.sendgrid_client.send_message(    ← translates to SendGrid's API
+      to=to,
+      subject=subject,
+      html_content=body,
+    )
+
+In tests: FakeEmailSender implements EmailSender — no HTTP calls.
+```
+
+---
+
+### Decorator
+
+Attach additional responsibilities to an object dynamically, without subclassing.
+
+**Use when** you want to add behaviour (logging, caching, validation, retries) to an object without modifying its class, and without creating a subclass for every combination of behaviours.
+
+**Testability**: Each decorator wraps a port interface and can be tested independently by passing in a mock of the wrapped interface.
+
+```
+interface Repository:
+  find(id)
+  save(entity)
+
+CachingRepository(Repository) implements Repository:
+  find(id):
+    if cache.has(id): return cache.get(id)
+    result = self.inner.find(id)
+    cache.set(id, result)
+    return result
+
+LoggingRepository(Repository) implements Repository:
+  save(entity):
+    logger.info('saving', entity.id)
+    self.inner.save(entity)
+
+In production: LoggingRepository(CachingRepository(PostgresRepository()))
+In tests:      test the domain with FakeRepository(); test CachingRepository separately.
+```
+
+---
+
+### Facade
+
+Provide a simplified interface to a complex subsystem.
+
+**Use when** a subsystem is complex or has many moving parts, and callers only need a narrow slice of its capabilities. The facade does not add behaviour — it simplifies access.
+
+**Testability**: The facade is itself a port-style interface from the caller's perspective. Mock the facade in tests for code that uses it; test the facade separately with integration tests.
+
+```
+COMPLEX subsystem: OrderValidator, InventoryChecker, PricingEngine, FraudDetector
+
+FACADE:
+  class CheckoutFacade:
+    def checkout(cart, payment):
+      self.validator.validate(cart)
+      self.inventory.reserve(cart.items)
+      price = self.pricing.calculate(cart)
+      self.fraud.screen(payment, price)
+      return self.payments.charge(payment, price)
+
+Callers depend on CheckoutFacade — not on the five subsystems.
+```
+
+---
+
+### Proxy
+
+Provide a surrogate or placeholder for another object to control access to it.
+
+**Use when** you need to add access control, lazy initialisation, remote communication, or logging around an object without the client knowing.
+
+**Common forms**: virtual proxy (defer expensive creation), protection proxy (access control), remote proxy (network call behind a local interface).
+
+**Testability**: Like Decorator, a proxy wraps an interface and can be tested by injecting a mock for the wrapped interface.
+
+```
+interface ImageLoader:
+  load(url) → Image
+
+LazyImageProxy implements ImageLoader:
+  load(url):
+    if not self._image:
+      self._image = RealImageLoader().load(url)   ← deferred until needed
+    return self._image
+```
+
+---
+
+### Bridge
+
+Separate an abstraction from its implementation so that the two can vary independently.
+
+**Use when** the abstraction and implementation should be extensible via subclassing, and a permanent binding between them would be inflexible. Also useful when implementation details should be hidden from the client entirely.
+
+**Key distinction from Adapter**: Adapter makes two incompatible existing interfaces work together (it fixes a mismatch after the fact). Bridge is designed upfront to allow both the abstraction and implementation to vary independently.
+
+**Testability**: The abstraction depends on an implementation interface — swap implementations in tests without changing the abstraction.
+
+```
+Abstraction: Report (defines what a report contains)
+Implementation interface: Renderer (defines how to render)
+
+Report → Renderer (interface)
+             ↑
+    HtmlRenderer   PdfRenderer   CsvRenderer
+
+SalesReport extends Report
+SummaryReport extends Report
+
+Both reports work with any renderer — add new report types or renderers independently.
+```
+
+---
+
+## Behavioral Patterns
+
+### Strategy
+
+Define a family of algorithms, encapsulate each one, and make them interchangeable.
+
+**Use when** you have multiple variants of a behaviour and want to select among them at runtime, or when you want to isolate the variation from the code that uses it.
+
+**This is the pattern behind the Open/Closed Principle**. Add new strategies without modifying existing code.
+
+**Testability**: Each strategy is a small, independently testable unit. The context class can be tested with a fake strategy.
+
+```
+interface SortStrategy:
+  sort(data) → data
+
+QuickSort  implements SortStrategy
+MergeSort  implements SortStrategy
+TimSort    implements SortStrategy
+
+class DataPipeline:
+  def __init__(self, sort_strategy: SortStrategy):
+    self.sort = sort_strategy
+
+  def process(data):
+    return self.sort.sort(data)
+```
+
+---
+
+### Observer
+
+Define a one-to-many dependency so that when one object changes state, all its dependents are notified automatically.
+
+**Use when** a change in one object requires updating others, and you do not want those objects tightly coupled.
+
+**Common names**: event system, pub/sub, signals, hooks, listeners.
+
+**Testability**: Inject a fake observer or collect emitted events in a list during tests. Never assert on internal state — assert on the events emitted through the observable interface.
+
+```
+interface OrderEventListener:
+  on_order_placed(order)
+
+class OrderService:
+  def __init__(self, listeners: list[OrderEventListener]):
+    self.listeners = listeners
+
+  def place_order(order):
+    ...
+    for listener in self.listeners:
+      listener.on_order_placed(order)
+
+In tests:
+  events = []
+  service = OrderService(listeners=[lambda o: events.append(o)])
+  service.place_order(order)
+  assert events[0].id == order.id
+```
+
+---
+
+### Command
+
+Encapsulate a request as an object, allowing parameterisation, queuing, logging, and undoable operations.
+
+**Use when** you need to: parameterise objects with operations, queue or log requests, support undo/redo, or decouple the sender of a request from its receiver.
+
+**Testability**: Commands are plain objects — they are trivially testable. Handlers that execute commands can be tested independently by constructing the command directly.
+
+```
+class TransferFundsCommand:
+  from_account: str
+  to_account:   str
+  amount:       Decimal
+
+class TransferFundsHandler:
+  def execute(cmd: TransferFundsCommand):
+    ...
+
+In tests:
+  handler = TransferFundsHandler(fake_repo)
+  handler.execute(TransferFundsCommand('A', 'B', 100))
+  assert fake_repo.balance('A') == original - 100
+```
+
+---
+
+### Template Method
+
+Define the skeleton of an algorithm in a base class, deferring some steps to subclasses.
+
+**Use when** you have an invariant algorithm structure but need to vary individual steps. The base class controls the sequence; subclasses fill in the details.
+
+**Prefer composition (Strategy) over inheritance (Template Method)** when the variation point can be isolated as a dependency. Template Method is appropriate when the steps are tightly bound to the algorithm's structure and separation via injection would be forced.
+
+```
+abstract class ReportGenerator:
+  generate(data):              ← template method — sequence is fixed
+    raw     = self.fetch(data)
+    cleaned = self.clean(raw)
+    return self.format(cleaned)
+
+  abstract fetch(data)         ← subclass provides these
+  abstract clean(data)
+  abstract format(data)
+
+CsvReportGenerator  extends ReportGenerator
+JsonReportGenerator extends ReportGenerator
+```
+
+---
+
+### Chain of Responsibility
+
+Pass a request along a chain of handlers, where each handler decides to process it or pass it on.
+
+**Use when** more than one object may handle a request, and the handler is not known at design time — or when you want to issue a request to one of several handlers without specifying the receiver explicitly.
+
+**Common uses**: middleware pipelines, validation chains, event bubbling.
+
+```
+interface RequestHandler:
+  handle(request) → response
+
+AuthMiddleware   implements RequestHandler
+LoggingMiddleware implements RequestHandler
+RateLimiter       implements RequestHandler
+ApplicationHandler implements RequestHandler
+
+pipeline = AuthMiddleware(LoggingMiddleware(RateLimiter(ApplicationHandler())))
+response = pipeline.handle(request)
+```
+
+---
+
+## Patterns to Approach with Caution
+
+| Pattern | Risk |
+|---------|------|
+| **Singleton** | Global state; test-hostile; use DI instead |
+| **Template Method** | Tight inheritance coupling; prefer Strategy |
+| **Visitor** | Hard to extend with new types; use polymorphism first |
+| **Mediator** | Can become a god object; keep it narrow |
+
+---
+
+## Choosing a Pattern
+
+Patterns are not solutions to invent problems for. Identify the design problem first, then check if a known pattern addresses it:
+
+| Problem | Pattern |
+|---------|---------|
+| Need to swap an algorithm at runtime | Strategy |
+| Need to add behaviour without subclassing | Decorator |
+| Need to integrate a foreign interface | Adapter |
+| Need to simplify a complex subsystem | Facade |
+| Need to notify dependents of a change | Observer |
+| Need to encapsulate a request as data | Command |
+| Need to create a family of related objects | Abstract Factory |
+| Need to build a complex object step by step | Builder |
+| Need to control access to an object | Proxy |
+| Need to create objects without specifying the exact type | Factory Method |
+| Need abstraction and implementation to vary independently | Bridge |
+| Need to share state across many fine-grained instances | Flyweight |
+
+---
+
+## Related Documents
+
+- `global/hexagonal-architecture.md` — Adapter is the structural pattern used to implement adapters in hexagonal architecture; ports are the Strategy-style interfaces the core depends on
+- `global/solid.md` — OCP is implemented via Strategy and Decorator; DIP is implemented via Adapter and Factory Method
+- `global/dry.md` — Builder and Factory Method centralise object-creation knowledge; Abstract Factory ensures families of objects are created consistently from one place

--- a/agent-os/standards/global/hexagonal-architecture.md
+++ b/agent-os/standards/global/hexagonal-architecture.md
@@ -1,0 +1,137 @@
+# Hexagonal Architecture and Orthogonal Design
+
+These two principles are the architectural foundation behind the "mock at system boundaries only" rule. Understanding them explains *why* the testing and mocking standards are written the way they are — not just *what* to do.
+
+---
+
+## Orthogonal Design
+
+**Orthogonality** means that a change to one component does not force a change to another. Two components are orthogonal when they are independent: you can modify, replace, or test either one without touching the other.
+
+### Rules
+
+- Separate concerns so that each module has one reason to change.
+- A component should not need to know how another component is implemented — only what it does.
+- Dependencies should flow in one direction. Circular dependencies are a sign of non-orthogonal design.
+- Design so that swapping an implementation (e.g. switching from one database to another) requires no changes to any component that did not directly depend on it.
+
+### Why It Matters for Testing
+
+When components are orthogonal, you can test each one in isolation. A test for business logic should not break because the database schema changed. A test for an HTTP adapter should not break because domain rules changed. Orthogonal design is what makes this possible.
+
+```
+NON-ORTHOGONAL — business logic depends on Stripe directly:
+  OrderService → StripeGateway
+  Changing payment provider requires rewriting OrderService tests.
+
+ORTHOGONAL — business logic depends on an interface:
+  OrderService → PaymentGateway (interface)
+                     ↑
+               StripeAdapter  BraintreeAdapter
+  Changing payment provider does not touch OrderService or its tests.
+```
+
+---
+
+## Hexagonal Architecture (Ports and Adapters)
+
+Hexagonal Architecture, defined by Alistair Cockburn, organises an application into three zones:
+
+```
+┌─────────────────────────────────────────────┐
+│              DRIVING ADAPTERS               │  ← Tests, HTTP controllers, CLI, message consumers
+│         (primary — drive the app)           │
+├─────────────────────────────────────────────┤
+│                                             │
+│             APPLICATION CORE               │  ← Domain logic, use cases, business rules
+│          (no I/O, no frameworks)            │
+│                                             │
+├─────────────────────────────────────────────┤
+│              DRIVEN ADAPTERS                │  ← Database, email, external APIs, message queues
+│       (secondary — driven by the app)       │
+└─────────────────────────────────────────────┘
+```
+
+### Ports
+
+A **port** is an interface defined by the application core. It describes what the application *needs* — not how it is provided.
+
+- **Driving ports** (primary): interfaces through which external actors interact with the core (e.g. `OrderService`, `UserService`).
+- **Driven ports** (secondary): interfaces the core calls outward (e.g. `PaymentGateway`, `UserRepository`, `EmailSender`).
+
+Ports belong to the core. They are defined in terms of the domain, not in terms of any specific technology.
+
+### Adapters
+
+An **adapter** is a concrete implementation of a port. It translates between the application's domain language and an external system.
+
+- A `StripeAdapter` implements `PaymentGateway`.
+- A `PostgresUserRepository` implements `UserRepository`.
+- An `HttpController` implements the driving port by calling `OrderService`.
+
+Adapters belong outside the core. They depend on the core; the core does not depend on them.
+
+### Rules
+
+- The application core must not import or reference any adapter, framework, or I/O library.
+- All I/O crosses the boundary through a port interface.
+- Adapters are the only place where third-party libraries (ORMs, HTTP clients, SDKs) appear.
+- Driven ports are what you inject into use cases and services — not concrete adapters.
+- Wrap any third-party library you do not own in an adapter. Never let a third-party type leak into the core.
+
+### Example
+
+```
+WRONG — core depends on a concrete adapter:
+  class OrderService:
+    def __init__(self):
+      self.payment = StripeGateway()   ← adapter imported into core
+
+CORRECT — core depends on a port:
+  class OrderService:
+    def __init__(self, payment: PaymentGateway):   ← port, not adapter
+      self.payment = payment
+
+In production:   OrderService(payment=StripeAdapter())
+In tests:        OrderService(payment=FakePaymentGateway())
+```
+
+---
+
+## How These Principles Drive the Mocking Rules
+
+The "mock at system boundaries only" rule is a direct consequence of hexagonal architecture:
+
+| Rule | Why |
+|------|-----|
+| Mock driven ports (external APIs, databases, etc.) | They are the outward boundary. Tests should verify the core behaves correctly given what the port returns. |
+| Do not mock your own classes or internal collaborators | Those are inside the core. Mocking them means testing structure, not behaviour. |
+| Mock interfaces (ports), not concrete implementations (adapters) | Tests should depend on the contract, not the wiring. |
+| Wrap third-party libraries in an adapter; mock the adapter | You do not own the third-party interface — it can change. Your adapter is the stable contract. |
+| Prefer dependency injection over internal construction | Ports must be injectable to be replaceable. |
+
+Orthogonality enforces this further: if your tests are hard to write without mocking internal collaborators, it means two concerns are entangled and need to be separated — the design is not orthogonal.
+
+```
+SIGNAL: "I need to mock UserService to test OrderService"
+CAUSE:  OrderService depends on UserService directly — they are not orthogonal
+FIX:    Introduce a port that represents only what OrderService needs from user data,
+        and depend on that interface instead
+```
+
+---
+
+## Summary
+
+- **Orthogonal design**: components change independently. Enables isolated testing.
+- **Hexagonal architecture**: core logic is surrounded by ports (interfaces) and adapters (implementations). The core has no knowledge of external systems.
+- **Consequence for mocking**: mock at ports (the boundary between core and adapters). Everything inside the core is tested directly; everything outside is replaced with a fake or stub.
+- **Consequence for design**: if mocking feels painful, the boundary is in the wrong place — fix the design, not the test.
+
+---
+
+## Related Documents
+
+- `global/solid.md` — the Dependency Inversion Principle (D) is the SOLID expression of hexagonal architecture; Interface Segregation (I) explains why ports should be narrow
+- `global/gang-of-four.md` — the Adapter pattern is how adapters are implemented; Strategy explains why the core can swap adapters at runtime
+- `global/dry.md` — keeping a single authoritative port definition prevents knowledge duplication across adapters

--- a/agent-os/standards/global/object-interaction.md
+++ b/agent-os/standards/global/object-interaction.md
@@ -1,0 +1,89 @@
+# Object Interaction
+
+These two principles govern how objects should talk to each other. Violations produce code that is tightly coupled to the internal structure of collaborators — fragile, hard to test, and hard to change.
+
+---
+
+## Law of Demeter (Principle of Least Knowledge)
+
+A method should only call methods on: (1) itself, (2) objects passed as parameters, (3) objects it creates, (4) its direct component objects (fields). It should not reach through an object to call methods on a returned object.
+
+### Rules
+
+- A method may call methods on `this`, its parameters, objects it creates locally, and its direct field dependencies.
+- A method must not call a method on an object returned by another method call (the "train wreck" smell: `a.getB().getC().doSomething()`).
+- Each "dot" after the first in a chain is a potential Demeter violation — the caller now depends on the internal structure of the object it received.
+- When you find yourself navigating a chain to do something, ask: should the intermediate object offer a method that does this for me?
+- Demeter violations make mocking painful: to test code that calls `order.getCustomer().getAddress().getCity()`, you must mock three layers.
+
+### Example
+
+```
+WRONG — violates Demeter, couples to internal structure:
+  city = order.getCustomer().getAddress().getCity()
+  discount = order.getCart().getPricingEngine().calculateDiscount(order)
+
+RIGHT — ask the object for what you need:
+  city = order.getShippingCity()         ← Order knows its shipping city
+  discount = order.calculateDiscount()   ← Order delegates to PricingEngine internally
+```
+
+### When to Accept a Chain
+
+Fluent interfaces and builder patterns are intentional chains where each method returns the same object type (`query.where().orderBy().limit()`). These are not Demeter violations — the chain does not navigate to a foreign object type.
+
+---
+
+## Tell, Don't Ask
+
+Tell an object what to do rather than asking it for its state and making decisions on its behalf outside the object.
+
+### Rules
+
+- If you find yourself reading an object's state, making a decision, then calling a method on the object based on that decision — move the decision into the object.
+- Objects should encapsulate both their state and the behaviour that operates on that state.
+- Asking for state to make a decision outside the object creates coupling: the caller now depends on the object's state representation.
+- The question "should this object be responsible for this decision?" almost always answers itself: if the decision uses only this object's data, yes.
+
+### Example
+
+```
+WRONG — Ask (caller interrogates state and decides):
+  if order.getStatus() == 'pending' and order.getPaymentStatus() == 'paid':
+    order.setStatus('confirmed')
+    order.sendConfirmation()
+
+RIGHT — Tell (caller delegates the decision):
+  order.confirm()   ← Order knows its own rules; caller just tells it what to do
+```
+
+---
+
+## How These Principles Relate to Testability
+
+Both principles reduce the number of objects a test must understand and mock:
+
+- Demeter: a method that only calls on direct collaborators needs only those collaborators mocked — not their internals.
+- Tell Don't Ask: a method that delegates decisions to objects has fewer branches to test — the decision logic is tested where it lives.
+
+```
+DEMETER VIOLATION — test must set up three levels of mocks:
+  mock_customer = Mock()
+  mock_address = Mock()
+  mock_order = Mock()
+  mock_order.getCustomer.return_value = mock_customer
+  mock_customer.getAddress.return_value = mock_address
+  mock_address.getCity.return_value = 'London'
+
+DEMETER COMPLIANT — test mocks one level:
+  mock_order = Mock()
+  mock_order.getShippingCity.return_value = 'London'
+```
+
+---
+
+## Related Documents
+
+- `global/solid.md` — SRP (each object is responsible for its own behaviour); DIP (depend on interfaces not structure)
+- `global/hexagonal-architecture.md` — ports enforce clean interaction boundaries; Demeter is naturally satisfied when talking to a port
+- `global/dry.md` — Ask-style code duplicates decision logic across callers; Tell centralises it

--- a/agent-os/standards/global/progressive-enhancement.md
+++ b/agent-os/standards/global/progressive-enhancement.md
@@ -1,0 +1,115 @@
+# Progressive Enhancement and Graceful Degradation
+
+Progressive Enhancement is a design philosophy: build a core that works under minimal conditions, then layer on enhancements that activate only when the required capabilities are available. Graceful Degradation is the consequence: when a capability is absent or fails, the system continues functioning in a reduced but acceptable form, rather than failing entirely.
+
+These two ideas are two sides of the same coin. Progressive enhancement is how you design a system from the start; graceful degradation is what you observe at runtime when optional dependencies are unavailable.
+
+---
+
+## Core Principle
+
+A system built with progressive enhancement satisfies two constraints at every level:
+
+1. **The core path always works.** The essential behaviour does not depend on any optional capability. Remove any enhancement, and the core still functions correctly.
+2. **Enhancements activate conditionally.** Before using an optional capability, the system checks whether it is available. If it is not, the system falls back to the core path.
+
+---
+
+## Rules
+
+- **Core behaviour must not depend on optional capabilities.** Design the core path first. Optional enhancements activate only after a successful availability check. If removing a feature flag or an external service would break the core, the dependency is not truly optional.
+- **Design every external dependency as optional where possible.** Before wiring a dependency into the core path, ask: what happens if this is slow? What happens if it is unavailable? What happens if it returns an error? The answer to each question should be a defined fallback, not an uncaught exception.
+- **Return partial results with a signal rather than failing entirely when non-critical components fail.** If a response depends on three backends and one times out, return the results from the two that succeeded along with a `warnings` field indicating what is missing. Never silently hide the degradation — callers need to know the response is partial.
+- **Use capability detection, not assumption.** Check whether a service or feature is available before using it. Do not assume that because a service was reachable at startup it will be reachable at request time.
+- **Circuit breakers and fallbacks are the infrastructure expression of this principle.** A circuit breaker detects that a downstream service is failing and routes traffic to a fallback instead of continuing to call the failing service. This is progressive enhancement applied at the infrastructure level.
+- **Never let a non-critical system failure become a critical one.** An analytics service going down must not prevent a checkout from completing. A recommendations engine returning an error must not prevent a product page from loading. Non-critical paths must be isolated from critical paths.
+
+---
+
+## Examples
+
+### Search with Elasticsearch fallback
+
+```
+function search(query):
+  if elasticsearch.isAvailable():
+    try:
+      return elasticsearch.search(query)
+    except ElasticsearchTimeout:
+      log.warning('Elasticsearch unavailable, falling back to database search')
+
+  # Core path — always works
+  return database.fullTextSearch(query)
+```
+
+The Elasticsearch integration is an enhancement. The core path (database full-text search) always works. The enhancement activates only after a successful availability check and falls back on error.
+
+### Recommendations engine returning a safe default
+
+```
+function getRecommendations(userId):
+  try:
+    return recommendationsService.forUser(userId, timeout=500ms)
+  except (ServiceUnavailable, Timeout):
+    log.warning('Recommendations service unavailable, returning empty list')
+    return []   ← safe default — page still renders
+
+# The calling page never receives an error.
+# It receives an empty list, which it handles gracefully.
+```
+
+### API response with partial data and warnings
+
+```
+function getDashboard(userId):
+  results = {}
+  warnings = []
+
+  results['profile'] = profileService.get(userId)          ← required, no fallback
+
+  try:
+    results['orders'] = orderService.recent(userId)
+  except Timeout:
+    warnings.append('Recent orders could not be loaded')
+
+  try:
+    results['recommendations'] = recommendationsService.get(userId)
+  except ServiceUnavailable:
+    results['recommendations'] = []
+    warnings.append('Recommendations are temporarily unavailable')
+
+  return { data: results, warnings: warnings }
+```
+
+The caller receives whatever data is available, plus a transparent account of what is missing.
+
+### Feature flags — progressive activation
+
+```
+function processPayment(order):
+  if featureFlags.isEnabled('new-payment-flow', order.userId):
+    return newPaymentProcessor.charge(order)     ← enhancement: new flow
+  return legacyPaymentProcessor.charge(order)    ← core: existing flow always works
+
+# The new payment flow is an enhancement.
+# It activates only for users in the feature flag cohort.
+# The existing flow is unchanged and always reachable.
+```
+
+---
+
+## Relationship to Circuit Breaker
+
+The circuit breaker is the implementation pattern; progressive enhancement is the design philosophy.
+
+A circuit breaker detects repeated failures from a downstream service and opens the circuit — subsequent calls are immediately routed to the fallback without attempting the service call, giving the service time to recover. The fallback is the progressive-enhancement core path.
+
+Without a defined fallback (i.e., without designing the system progressively), a circuit breaker has nowhere to route traffic — it can only fail fast. The circuit breaker is only useful when there is a degraded-but-functional path to fall back to.
+
+---
+
+## Related Documents
+
+- `global/hexagonal-architecture.md` — external dependencies enter through ports; designing a port's fallback behaviour is where progressive enhancement is expressed in hexagonal architecture
+- `global/solid.md` — the Open/Closed Principle (OCP) is related: adding a new capability (an enhancement) should not require modifying the core path; the core remains closed to modification while new enhancements are added by extension
+- `global/gang-of-four.md` — the Proxy pattern can implement fallback logic: a proxy attempts the real implementation and falls back to a safe alternative when the real implementation fails

--- a/agent-os/standards/global/simplicity.md
+++ b/agent-os/standards/global/simplicity.md
@@ -1,0 +1,100 @@
+# Simplicity
+
+Simplicity is an active discipline, not the absence of effort. The simplest solution that works is almost always the best one. Complexity is the primary cost in software — it makes code harder to read, test, change, and delete.
+
+---
+
+## YAGNI — You Aren't Gonna Need It
+
+Do not add functionality until it is needed. Build what the current requirement demands, not what you imagine future requirements might demand.
+
+### Rules
+
+- Do not add parameters, configuration options, or extension points that no current caller uses.
+- Do not abstract prematurely. Two lines of similar code is not a problem. An unnecessary abstraction is.
+- Do not write code for hypothetical future requirements. Requirements change; speculative code becomes wrong code that must be maintained or deleted.
+- Every line of code is a liability: it must be read, understood, tested, and maintained. Code that does not exist has no cost.
+- When you genuinely need the feature, add it then — it will be informed by real requirements and real context.
+
+### Example
+
+```
+WRONG — speculative extensibility no caller uses:
+  function createUser(data, options = {
+    notificationChannel: 'email',
+    auditLog: true,
+    retryOnFailure: false,
+    ... 8 more options nobody asked for
+  })
+
+RIGHT — build what is needed now:
+  function createUser(data)
+  # add options when a real requirement demands them
+```
+
+---
+
+## KISS — Keep It Simple
+
+Prefer the simplest solution that correctly solves the problem. Do not introduce accidental complexity.
+
+### Rules
+
+- Choose boring technology when it solves the problem. Reach for a complex solution only when a simpler one is demonstrably insufficient.
+- Flat is better than nested. A function with three levels of nesting is a candidate for extraction.
+- Direct is better than clever. Code that requires a comment to explain what it does is more complex than code that does not.
+- The simplest data structure that works is the right one. A plain list is better than a custom tree if a list solves the problem.
+- If you cannot explain the solution to a colleague in two sentences, it may be too complex.
+
+### Example
+
+```
+WRONG — clever, fragile, hard to follow:
+  result = data.reduce((acc, x) => ({...acc, [x.id]: [...(acc[x.id] || []), x]}), {})
+
+RIGHT — direct, readable:
+  grouped = {}
+  for item in data:
+    if item.id not in grouped:
+      grouped[item.id] = []
+    grouped[item.id].append(item)
+```
+
+---
+
+## Kent Beck's Four Rules of Simple Design
+
+In priority order — higher rules take precedence over lower ones.
+
+1. **Passes the tests** — The code must do what is required. No other rule matters if this one is not met.
+2. **Reveals intention** — The code communicates its purpose through names, structure, and flow. A reader should understand what the code does without needing to run it.
+3. **No duplication** — Every piece of knowledge has a single authoritative representation. (See `global/dry.md`.)
+4. **Fewest elements** — Given the above constraints, remove every class, function, variable, and parameter that is not necessary. Fewer elements means less to understand, test, and maintain.
+
+### Rules
+
+- Apply the Four Rules in order. A cleverly minimal solution that fails tests or obscures intent violates a higher rule.
+- "Reveals intention" is the rule most often violated by AI-generated code — ask: does this name, structure, and abstraction communicate what it does and why?
+- "Fewest elements" is not about line count. A well-named ten-line function with one clear purpose has fewer elements than a three-line function that requires three comments to understand.
+- Run the Four Rules as a checklist after each TDD cycle — they are the refactoring criterion.
+
+### Example
+
+```
+After GREEN — evaluate with the Four Rules:
+
+1. Passes tests?          → yes
+2. Reveals intention?     → does getUsersByStatus(status) clearly say what it does? yes
+3. No duplication?        → is the status-filter logic copied elsewhere? no
+4. Fewest elements?       → is there a parameter, variable, or method that can be removed?
+                            → the `tempList` variable is unnecessary — filter directly
+```
+
+---
+
+## Related Documents
+
+- `global/dry.md` — Rule 3 (No duplication) in depth
+- `global/tdd-workflow.md` — the TDD cycle is where the Four Rules are applied
+- `global/solid.md` — SOLID principles are specific applications of these broader simplicity rules
+- `global/gang-of-four.md` — patterns solve recurring problems; YAGNI says do not apply a pattern until the problem is actually present

--- a/agent-os/standards/global/solid.md
+++ b/agent-os/standards/global/solid.md
@@ -1,0 +1,194 @@
+# SOLID Principles
+
+SOLID is five design principles that, applied together, produce code that is easy to test, extend, and maintain. They are not rules to apply mechanically — they are heuristics for managing the cost of change. Each principle describes a different way that a design can resist or invite unnecessary coupling.
+
+---
+
+## S — Single Responsibility Principle
+
+A module should have one reason to change.
+
+A "reason to change" means a stakeholder or concern whose requirements could cause the module to be modified. If two different stakeholders could independently ask for changes to the same module, that module has more than one responsibility and should be split.
+
+### Rules
+
+- A class or function that does two conceptually separate things should become two.
+- I/O, transformation, and validation are almost always separate responsibilities — do not mix them in a single function.
+- If you struggle to name a module without using "and" or "or", it probably has more than one responsibility.
+- Symptoms of violation: long files, functions that need extensive mocking to test, and frequent merge conflicts in the same file from unrelated features.
+
+### Example
+
+```
+WRONG — three responsibilities in one class:
+  OrderProcessor
+    validate(order)       ← validation concern
+    save(order)           ← persistence concern
+    sendConfirmation()    ← notification concern
+
+RIGHT — one responsibility each:
+  OrderValidator.validate(order)
+  OrderRepository.save(order)
+  OrderNotifier.sendConfirmation(order)
+```
+
+---
+
+## O — Open/Closed Principle
+
+A module should be open for extension but closed for modification.
+
+Once a module is working and tested, new behaviour should be added by extending it — not by editing it. Editing existing code risks breaking existing tests and existing callers.
+
+### Rules
+
+- Favour extension points (interfaces, abstract classes, callbacks, composition) over if/switch chains that grow with every new case.
+- When adding a new variant of behaviour, ask: can I add a new class/function rather than modify an existing one?
+- A long if/switch that must be edited every time a new type is added is a violation — introduce a polymorphic interface instead.
+- This principle is most valuable at stable, high-use boundaries. Do not apply it prematurely to code that is still being discovered.
+
+### Example
+
+```
+WRONG — must modify existing code to add a new discount type:
+  function applyDiscount(order, type):
+    if type == 'percent': ...
+    if type == 'fixed':   ...
+    if type == 'loyalty': ...   ← edit required for each new type
+
+RIGHT — extend by adding a new implementation:
+  interface DiscountStrategy:
+    apply(order) → amount
+
+  PercentDiscount implements DiscountStrategy
+  FixedDiscount   implements DiscountStrategy
+  LoyaltyDiscount implements DiscountStrategy   ← no existing code modified
+```
+
+---
+
+## L — Liskov Substitution Principle
+
+A subtype must be substitutable for its base type without altering the correctness of the program.
+
+If code works with a `Shape`, it must continue to work correctly when passed a `Circle` or `Rectangle` without knowing which it received. Violations mean the abstraction is wrong — the types are not truly interchangeable.
+
+### Rules
+
+- A subtype must honour the contract of its base type: preconditions cannot be strengthened, postconditions cannot be weakened, invariants must be preserved.
+- If a subclass overrides a method in a way that changes its observable behaviour (not just implementation), that is a Liskov violation.
+- If calling code needs to inspect the concrete type before using it (`if isinstance(x, SubclassA)`), the abstraction is broken.
+- Prefer composition over inheritance when the "is-a" relationship is forced or partial.
+
+### Example
+
+```
+WRONG — Square violates Rectangle's contract:
+  Rectangle.setWidth(w)  sets width, height unchanged
+  Square.setWidth(w)     sets both width AND height  ← violates expectation
+
+  Code that relies on Rectangle's contract breaks when given a Square.
+
+RIGHT — do not inherit where the contract cannot be honoured:
+  Use a common Shape interface with an area() method only.
+  Rectangle and Square implement Shape independently.
+```
+
+---
+
+## I — Interface Segregation Principle
+
+Clients should not be forced to depend on methods they do not use.
+
+A large interface forces every implementor to provide all methods and every caller to import the whole contract, even when only a fraction is needed. Split interfaces along the lines of what each caller actually needs.
+
+### Rules
+
+- Define narrow, role-specific interfaces rather than wide, catch-all ones.
+- If a class implements an interface and leaves some methods as `raise NotImplementedError` or empty stubs, the interface is too wide — split it.
+- Each caller should depend on the smallest interface that satisfies its needs.
+- Narrow interfaces are easier to mock: a mock only needs to implement the methods the code under test actually calls.
+
+### Example
+
+```
+WRONG — one wide interface forces unneeded dependencies:
+  interface Worker:
+    work()
+    eat()
+    sleep()
+
+  RobotWorker must implement eat() and sleep() despite not needing them.
+
+RIGHT — split by role:
+  interface Workable:  work()
+  interface Feedable:  eat()
+  interface Restable:  sleep()
+
+  HumanWorker  implements Workable, Feedable, Restable
+  RobotWorker  implements Workable
+```
+
+---
+
+## D — Dependency Inversion Principle
+
+High-level modules should not depend on low-level modules. Both should depend on abstractions. Abstractions should not depend on details.
+
+This is the principle that makes hexagonal architecture work. The application core (high-level) defines port interfaces. Adapters (low-level) implement those interfaces. The core never imports the adapter — the dependency arrow points inward, toward the core.
+
+### Rules
+
+- High-level policy (business logic) must not import low-level mechanism (database, HTTP client, file system).
+- Define the interface in terms of the domain, in the same layer as the code that uses it.
+- Inject dependencies through constructors or function parameters — never instantiate them internally.
+- This principle is the primary enabler of testability: when high-level code depends on an interface, tests pass a fake; production code passes the real adapter.
+
+### Example
+
+```
+WRONG — high-level module depends on low-level detail:
+  class OrderService:
+    def __init__(self):
+      self.db = PostgresDatabase()   ← imports low-level adapter directly
+
+  OrderService is now untestable without a real Postgres instance.
+
+RIGHT — both depend on an abstraction:
+  interface OrderRepository:           ← defined in the domain layer
+    save(order)
+    find_by_id(id)
+
+  class OrderService:
+    def __init__(self, repo: OrderRepository):   ← depends on interface
+      self.repo = repo
+
+  class PostgresOrderRepository(OrderRepository): ...   ← adapter depends on interface
+
+  In tests:   OrderService(repo=FakeOrderRepository())
+  In prod:    OrderService(repo=PostgresOrderRepository(db))
+```
+
+---
+
+## How SOLID Relates to Hexagonal Architecture and Orthogonal Design
+
+These principles are not independent ideas — they reinforce each other:
+
+| Principle | Connection |
+|-----------|------------|
+| **SRP** | Each port and each adapter has one responsibility. |
+| **OCP** | New adapters extend the system without modifying the core. |
+| **LSP** | All adapters for a port are substitutable — tests can use fakes. |
+| **ISP** | Ports are narrow; each caller depends only on what it needs. |
+| **DIP** | The core defines ports; adapters implement them. Dependency arrows point inward. |
+
+Violating any of these principles typically makes testing harder. If a test requires excessive setup, broad mocking, or knowledge of internal structure, trace the pain back to a SOLID violation — then fix the design.
+
+---
+
+## Related Documents
+
+- `global/hexagonal-architecture.md` — the structural application of DIP and ISP; ports are the narrow interfaces the core defines
+- `global/gang-of-four.md` — Strategy implements OCP; Adapter implements DIP; Decorator implements OCP without subclassing
+- `global/dry.md` — SRP and DRY reinforce each other: a module with one responsibility has one place where each piece of knowledge lives

--- a/agent-os/standards/global/tdd-workflow.md
+++ b/agent-os/standards/global/tdd-workflow.md
@@ -1,0 +1,283 @@
+# TDD Workflow
+
+Test-Driven Development is a design discipline, not a testing strategy. Tests written before implementation drive smaller interfaces, tighter scope, and code that is testable by construction. Tests should verify behaviour through public interfaces — not implementation details. Code can change entirely; tests should not need to.
+
+---
+
+## Planning Before You Start
+
+### Rules
+
+- Before writing any code, confirm what interface changes are needed and which behaviours to test.
+- List the behaviours to test — not implementation steps. Get alignment before writing any test.
+- You cannot test everything. Prioritise critical paths and complex logic over exhaustive edge-case coverage.
+- Identify opportunities for deep modules and design interfaces for testability before committing to a structure.
+
+---
+
+## The Red-Green-Refactor Cycle
+
+Every unit of work follows three steps in order, without skipping.
+
+### Rules
+
+- **Red** — Write one failing test that describes the behaviour you intend to implement. Run it. Confirm it fails for the right reason.
+- **Green** — Write the minimum code required to make that one test pass. No more.
+- **Refactor** — Improve the code while keeping all tests green. Never refactor while any test is red.
+- Do not write implementation code before a failing test exists.
+- Do not refactor and add behaviour in the same step.
+
+### Example
+
+```
+RED:   write test → run → confirm it fails for the right reason
+GREEN: write minimal code → run → confirm it passes
+REFACTOR: improve code → run → confirm still green
+
+Repeat for next behaviour.
+```
+
+---
+
+## Vertical Slices — Not Horizontal
+
+### Rules
+
+- Do not write all tests first and then all implementation. This is horizontal slicing and produces tests that verify imagined behaviour, not actual behaviour.
+- Horizontal slicing causes tests to become insensitive to real changes — they pass when behaviour breaks and fail when behaviour is fine. You commit to test structure before understanding the implementation.
+- Work in vertical slices: one test → one implementation → repeat. Each test responds to what you learned from the previous cycle.
+- This is called the **tracer bullet** approach — prove one path works end-to-end before widening.
+
+### Example
+
+```
+WRONG (horizontal slicing):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical slices):
+  RED → GREEN: test1 → impl1
+  RED → GREEN: test2 → impl2
+  RED → GREEN: test3 → impl3
+```
+
+---
+
+## Spec-First Development with Agent-OS
+
+### Rules
+
+- A spec in `agent-os/specs/` is the gate before any implementation begins.
+- Run `/shape-spec` and create a spec before writing any code.
+- Acceptance criteria in the spec map one-to-one to test cases.
+- The AI agent must not write implementation until the spec exists and at least one failing test is committed.
+- If a user says "just build it" without a spec, pause and create the spec first.
+- Do not open an implementation PR without a corresponding spec.
+
+### Example
+
+```
+1. /shape-spec → spec written to agent-os/specs/<feature>.md
+2. Write tests → commit: "test: add failing tests for <feature>"  → confirm RED
+3. Implement  → commit: "feat: implement <feature>"              → confirm GREEN
+4. Refactor   → commit: "refactor: tidy <feature>"              → confirm still GREEN
+5. PR         → spec + tests + implementation ship together
+```
+
+---
+
+## What to Test
+
+### Rules
+
+- Test behaviour through public interfaces only — never test private methods or internal collaborators.
+- A good test reads like a specification: "user can checkout with valid cart" describes a capability.
+- A test that breaks when you refactor internal structure (without changing behaviour) is testing implementation, not behaviour — fix or delete it.
+- Mock only at system boundaries: external APIs, databases, time/randomness, filesystem. Do not mock your own classes or internal collaborators.
+- Test one logical concept per test case.
+- Never verify behaviour through external means (e.g. querying a database directly) when the public interface can be used instead.
+
+### Bad test warning signs
+
+- Mocking internal collaborators or your own classes
+- Testing private methods
+- Asserting on call counts, call order, or internal flag state
+- Test name describes *how* the code works, not *what* it does
+- Test breaks when refactoring without any behaviour change
+- Verification bypasses the public interface (e.g. reads directly from a database instead of calling the retrieval function)
+
+### Example
+
+```
+GOOD — tests observable behaviour through public interface:
+  it('returns zero LHC loading for members under 31')
+  it('makes a created user retrievable by ID')
+  it('returns 400 when conversationId is missing')
+
+BAD — tests implementation details:
+  it('calls paymentService.process with the correct total')
+  it('sets the isLoading flag to true during fetch')
+  it('saves to the users table')
+
+BAD — bypasses public interface to verify:
+  createUser({ name: 'Alice' })
+  // then queries the database directly to check the row
+
+GOOD — verifies through the public interface:
+  user = createUser({ name: 'Alice' })
+  retrieved = getUser(user.id)
+  assert retrieved.name == 'Alice'
+```
+
+---
+
+## Test Levels
+
+### Rules
+
+- **Unit** — pure functions, business logic, domain calculations. No I/O, no network. Mock at the port/interface boundary only.
+- **Integration** — HTTP routes, adapter implementations, database queries. Test the contract, not internals. Use in-memory fakes or test containers.
+- **End-to-end** — critical user journeys only. Mark and skip in fast CI runs; run on demand.
+- Many unit → fewer integration → very few E2E.
+- Never use integration tests to cover logic that belongs in unit tests.
+
+---
+
+## Deep Modules and Testable Interfaces
+
+Design for deep modules: small interface, lots of hidden implementation. The smaller the interface, the fewer tests needed. The simpler the parameters, the simpler the test setup.
+
+### Rules
+
+- Accept dependencies as parameters rather than creating them internally — this makes every function trivially testable and mockable.
+- Return results rather than producing side effects — pure functions are always easier to test.
+- Prefer specific interfaces over generic ones — one function per external operation is easier to mock than one generic dispatcher.
+- Ask before implementing: can I reduce the number of methods? Can I simplify the parameters? Can I hide more complexity inside?
+
+### Example
+
+```
+Deep module (testable):
+┌─────────────────────┐
+│  Small Interface    │  ← few methods, simple params
+├─────────────────────┤
+│                     │
+│  Deep Implementation│  ← complex logic hidden inside
+│                     │
+└─────────────────────┘
+
+Shallow module (hard to test):
+┌─────────────────────────────────┐
+│       Large Interface           │  ← many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← just passes through
+└─────────────────────────────────┘
+
+TESTABLE — accepts dependency, returns result:
+  processOrder(order, paymentGateway) → result
+
+HARD TO TEST — creates dependency internally, produces side effect:
+  processOrder(order) {
+    gateway = new StripeGateway()   // hidden dep, cannot mock
+    cart.total -= discount          // side effect, cannot assert cleanly
+  }
+```
+
+---
+
+## Mocking
+
+Mock at system boundaries only. Do not mock what you own. This rule is a direct consequence of hexagonal architecture and orthogonal design — see `global/hexagonal-architecture.md` for the underlying principles.
+
+### Rules
+
+- Mock driven ports (external APIs, databases, message queues, time, randomness, the filesystem) — these are the boundary between your application core and the outside world.
+- Do not mock your own classes, internal collaborators, or anything you control. If a test is painful without mocking internals, the components are not orthogonal — fix the design, not the test.
+- Mock interfaces (ports), not concrete adapter implementations. Tests should depend on the contract, not the wiring.
+- Wrap any third-party library you do not own in an adapter and mock the adapter — never let a third-party type leak into the core.
+- Design for mockability: prefer dependency injection and SDK-style interfaces over generic fetchers.
+- Prefer specific functions per external operation over one generic dispatcher — each specific function is independently mockable with no conditional logic in the mock.
+- Reset mocks between tests to prevent pollution.
+- For language and framework-specific mocking examples, see your profile's `testing/mocking.md`.
+
+### Example
+
+```
+GOOD — specific SDK-style interface, each operation independently mockable:
+  api.getUser(id)
+  api.getOrders(userId)
+  api.createOrder(data)
+
+BAD — generic fetcher, mock requires conditional logic to handle different endpoints:
+  api.fetch(endpoint, options)
+
+GOOD — dependency injected, easy to substitute a mock:
+  processPayment(order, paymentClient)
+
+BAD — dependency created internally, cannot be substituted:
+  processPayment(order) { client = new StripeClient() }
+```
+
+---
+
+## Refactoring After Green
+
+### Rules
+
+- Only refactor when all tests are green.
+- After each TDD cycle, look for: duplication, long methods, shallow modules, feature envy, primitive obsession.
+- **Duplication** — extract into a shared function or class.
+- **Long methods** — break into private helpers; keep tests on the public interface, not the helpers.
+- **Shallow modules** — combine or deepen; push complexity behind the interface.
+- **Feature envy** — move logic to the module where the data lives.
+- **Primitive obsession** — introduce value objects or domain types.
+- Consider what the new code reveals about existing code — refactor that too if it is now obviously wrong.
+- Run tests after each refactor step before continuing.
+
+---
+
+## Per-Cycle Checklist
+
+After each red-green step, verify:
+
+```
+[ ] Test describes behaviour, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive an internal refactor
+[ ] Implementation code is minimal for this test
+[ ] No speculative features were added
+```
+
+---
+
+## Commit Discipline
+
+### Rules
+
+- Commit failing tests before implementation — this creates an auditable red-green history.
+- Use Conventional Commits: `test:` for test-only commits, `feat:` for implementation, `refactor:` for cleanup.
+- Never mix test additions, implementation, and refactoring in a single commit.
+
+### Example
+
+```
+git log --oneline
+
+a1b2c3d refactor: extract premium calculation into pure function
+9e8f7g6 feat: implement get_recommended_products
+5d4c3b2 test: add failing tests for premium calculation
+```
+
+---
+
+## AI Agent Rules
+
+### Rules
+
+- Before writing any implementation, check: does a spec exist in `agent-os/specs/`? If not, create one first.
+- Write failing tests and confirm they are red before writing any implementation code.
+- Do not mark a task complete until all tests are green and committed.
+- Do not generate placeholder tests that always pass — tests must assert real behaviour.
+- Commit failing tests and passing implementation as separate commits.
+- If the user says "skip the tests", explain the risk and add tests immediately after — never skip silently.
+- Do not call real external APIs (LLMs, payment gateways, etc.) in unit tests — mock at the boundary.

--- a/agent-os/standards/global/value-objects.md
+++ b/agent-os/standards/global/value-objects.md
@@ -1,0 +1,91 @@
+# Value Objects
+
+A Value Object is an object whose identity is defined entirely by its value, not by a reference or database ID. Two value objects with the same data are interchangeable. They are always immutable. They eliminate Primitive Obsession — the code smell of using raw strings, integers, and floats to represent domain concepts.
+
+---
+
+## What Is a Value Object
+
+### Rules
+
+- A Value Object has no identity beyond its value. Two Money objects of £10.00 GBP are equal; it does not matter which one you use.
+- Value Objects are always immutable. Operations that would "change" a Value Object return a new instance.
+- Value Objects encapsulate validation. An Email object cannot represent an invalid email — the constructor enforces the invariant.
+- Value Objects carry domain semantics. `Money(10.00, 'GBP')` communicates more than `float 10.0`.
+- Value Objects should define equality based on their contents, not their reference.
+
+### Example
+
+```
+WITHOUT value objects — Primitive Obsession:
+  function transfer(fromAccount, toAccount, amount: float, currency: string)
+
+  transfer(account1, account2, 100.0, 'GBP')   ← nothing prevents:
+  transfer(account1, account2, 'GBP', 100.0)   ← swapped params, compiles, wrong
+  transfer(account1, account2, -50.0, 'GBP')   ← negative amount, no validation
+
+WITH value objects:
+  function transfer(fromAccount, toAccount, amount: Money)
+
+  money = Money(100.0, Currency.GBP)            ← validated at construction
+  transfer(account1, account2, money)           ← param order enforced by type
+```
+
+---
+
+## When to Introduce a Value Object
+
+### Rules
+
+- When a primitive has validation rules (email format, positive amounts, non-empty names).
+- When a primitive carries units or constraints that must be enforced everywhere it is used.
+- When the same primitive appears together with another in multiple places (street + city + postcode → Address).
+- When code is littered with validation of the same raw primitive in multiple locations.
+- When a function takes two or more primitives of the same type that could be accidentally swapped.
+
+### Primitive Obsession Signals
+
+```
+SIGNALS — consider a Value Object:
+  function setAge(age: int)                             ← can pass negative or 200
+  function createUser(email: string)                    ← can pass any string
+  function charge(amount: float, currency: string)      ← units and currency coupled
+  if len(name) > 0 and '@' in email and ...            ← validation duplicated across codebase
+```
+
+---
+
+## Value Object vs Entity
+
+- **Entity**: has an identity independent of its values. Two Users with the same name are not the same User — they have different IDs. Entities are mutable over time.
+- **Value Object**: has no identity beyond its value. Two Money(10, GBP) instances are interchangeable. Value Objects are immutable.
+
+```
+Entity:   User(id=1, name='Alice')  ≠  User(id=2, name='Alice')   ← different identity
+Value:    Money(10, GBP)            =  Money(10, GBP)              ← same value, interchangeable
+```
+
+---
+
+## Immutability and Operations
+
+### Rules
+
+- Operations on a Value Object return a new instance — never mutate the original.
+- This makes Value Objects safe to share, cache, and use as dictionary keys.
+
+### Example
+
+```
+money = Money(100, 'GBP')
+discounted = money.subtract(Money(10, 'GBP'))   ← returns new Money(90, 'GBP')
+# money is still Money(100, 'GBP')
+```
+
+---
+
+## Related Documents
+
+- `global/dry.md` — Value Objects eliminate duplicated validation logic (single authoritative representation of the constraint)
+- `global/solid.md` — SRP: each Value Object is responsible for the validity and behaviour of one domain concept
+- `global/gang-of-four.md` — Flyweight: immutable Value Objects are natural candidates for flyweight sharing

--- a/agent-os/standards/index.yml
+++ b/agent-os/standards/index.yml
@@ -1,0 +1,50 @@
+# Agent OS Standards Index
+
+books:
+  book-map-conventions:
+    description: BOOK_MAP key casing rules, abbrev source, and alternative name pattern
+  single-chapter-books:
+    description: Why singleChapter:true books use [[Abbrev#vN]] not [[Abbrev-01#vN]]
+
+config:
+  obsidian-links-opt-out:
+    description: INCLUDE_OBSIDIAN_LINKS opt-out design; only 'false' disables it
+  startup-config-loading:
+    description: Config loaded once at module init; env changes require server restart
+
+enrichment:
+  double-link-prevention:
+    description: Regex lookbehind/lookahead guards for idempotency and link preservation
+  implicit-chapter-inheritance:
+    description: parseChapterVerse() chapter propagation across comma-separated verse groups
+  three-pass-ordering:
+    description: Strict pass order in enrichMarkdown() and why it must not change
+
+global:
+  coupling-cohesion:
+    description: Needs description - run /index-standards
+  delegation:
+    description: Needs description - run /index-standards
+  dry:
+    description: Needs description - run /index-standards
+  gang-of-four:
+    description: Needs description - run /index-standards
+  hexagonal-architecture:
+    description: Needs description - run /index-standards
+  object-interaction:
+    description: Needs description - run /index-standards
+  progressive-enhancement:
+    description: Needs description - run /index-standards
+  simplicity:
+    description: Needs description - run /index-standards
+  solid:
+    description: Needs description - run /index-standards
+  tdd-workflow:
+    description: Needs description - run /index-standards
+  value-objects:
+    description: Needs description - run /index-standards
+
+testing:
+  config-module-cache-limitation:
+    description: Why process.env changes in Jest beforeEach don't affect enrichment config
+

--- a/agent-os/standards/testing/config-module-cache-limitation.md
+++ b/agent-os/standards/testing/config-module-cache-limitation.md
@@ -1,0 +1,30 @@
+---
+name: Config Module Cache Limitation
+description: Why process.env changes in Jest beforeEach don't affect enrichment config
+type: project
+---
+
+# Config Module Cache Limitation
+
+`enrichment.ts` loads config at module init (`const config = loadConfig()`).
+Jest caches modules between tests, so changing `process.env` in `beforeEach`
+does **not** affect the `config` object already in memory.
+
+```typescript
+// This does NOT work — config is already cached
+beforeEach(() => {
+  process.env.BIBLE_VERSION = 'ESV';
+});
+```
+
+## Workarounds
+
+1. **Mock `loadConfig`** using `jest.mock('../config.js')` to return a specific config
+2. **Accept startup defaults** — tests that check config-driven output verify against
+   whatever env was set when the test process started
+3. **Integration test via env** — set env vars before running Jest (e.g. in a separate
+   test script or CI job)
+
+The two config tests in `enrichment.test.ts` (lines 169-189) use option 2 and
+are effectively no-ops for config variation — they confirm the output format,
+not that config switching works.


### PR DESCRIPTION
## Summary

- Adds `agent-os/standards/` directory with 19 standards files
- Covers enrichment logic, book map conventions, config behaviour, and testing limitations
- Includes global engineering standards (SOLID, DRY, TDD, etc.)

## Standards added

| Area | Files |
|------|-------|
| `enrichment/` | three-pass-ordering, implicit-chapter-inheritance, double-link-prevention |
| `config/` | startup-config-loading, obsidian-links-opt-out |
| `books/` | book-map-conventions, single-chapter-books |
| `testing/` | config-module-cache-limitation |
| `global/` | 11 general engineering standards |

## Test plan

- [x] Review standards files for accuracy
- [x] Confirm `agent-os/standards/index.yml` entries match file names

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)