### PR TITLE
feat: add agentic scaffolding, changelog, contributing docs, and Claude skills

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: changelog
+description: >
+  Updates CHANGELOG.md by collecting git commits since the last tag, categorising
+  them into Keep a Changelog v1.1.0 sections (Added, Changed, Fixed, etc.), and
+  cutting a new versioned release entry. Called autonomously by the `release` skill.
+  Accepts VERSION and optional DATE arguments. Do not trigger on general conversation
+  — only activate when explicitly called by another skill or invoked directly as
+  /changelog <version> [date].
+---
+
+# Changelog Skill
+
+## Usage
+
+Called by the `release` skill, or directly:
+
+```
+/changelog <version>
+/changelog <version> <date>
+```
+
+Examples:
+```
+/changelog 1.2.0
+/changelog 1.2.0 2026-05-19
+```
+
+Arguments:
+- `VERSION` — required. Semantic version string, e.g. `1.2.0` or `2.0.0-beta.1`.
+- `DATE` — optional. ISO date `YYYY-MM-DD`. Defaults to today.
+- `MAX_FULL_ENTRIES` — optional. Integer. When the file already contains more than this many
+  versioned entries, entries beyond the threshold are collapsed to links-only (heading and
+  comparison link remain; entry body is removed). Default: no limit (all entries kept in full).
+
+---
+
+## Commit-to-Section Mapping
+
+Conventional Commits prefixes map to Keep a Changelog sections:
+
+| Commit prefix | Changelog section |
+|---|---|
+| `feat:` / `feat!:` | Added |
+| `fix:` / `fix!:` | Fixed |
+| `security:` | Security |
+| `deprecate:` | Deprecated |
+| `remove:` / `revert:` | Removed |
+| `refactor:` / `perf:` / `style:` | Changed |
+| `docs:` | Changed |
+| `chore:` / `ci:` / `build:` / `test:` | *(skip — not user-facing)* |
+| *(no recognised prefix)* | Changed |
+| Any commit with `BREAKING CHANGE` in body or `!` after type | Prefix entry with **BREAKING:** |
+
+**Chores that are always skipped, even when they look meaningful:**
+
+- Version bump commits ("Bump version to X.Y.Z", "chore: release X.Y.Z") — the versioned heading
+  itself is the release record; a separate entry would duplicate it.
+- Tagging commits — implied by the heading date and comparison link.
+- Dependency version bumps (`build(deps):`, `chore(deps):`) without an explicit security advisory
+  callout in the commit body — purely internal. If a commit message explicitly names a CVE or
+  advisory (e.g. "fix CVE-2025-1234"), treat it as `security:` and include it under Security.
+- Changelog update commits ("docs: update CHANGELOG") — the file is self-describing.
+
+---
+
+## Step 1 — Resolve Arguments
+
+Parse `VERSION` from the argument. If missing, stop:
+
+> "Usage: /changelog <version> [date]
+> Example: /changelog 1.2.0"
+
+Resolve `DATE`: use the supplied date if provided, otherwise use today's date in `YYYY-MM-DD` format.
+
+---
+
+## Step 2 — Detect Repository Context
+
+```bash
+# Get the GitHub repo URL for comparison links
+git remote get-url origin
+```
+
+Derive `REPO_URL` in `https://github.com/{owner}/{repo}` form by converting SSH remote syntax
+(`git@github.com:{owner}/{repo}.git`) if needed.
+
+---
+
+## Step 3 — Find the Last Tag
+
+```bash
+git tag --sort=-version:refname | head -1
+```
+
+Store as `LAST_TAG`. If no tags exist, store as empty string and collect the full commit history
+in Step 4.
+
+---
+
+## Step 4 — Collect Commits
+
+```bash
+# With a previous tag
+git log {LAST_TAG}..HEAD --oneline --no-merges --format="%s"
+
+# No previous tag — full history
+git log --oneline --no-merges --format="%s"
+```
+
+Collect all commit subjects. Ignore merge commits (`--no-merges`). Store as `COMMITS`.
+
+---
+
+## Step 5 — Categorise Commits
+
+For each commit subject in `COMMITS`:
+
+1. Strip the scope, e.g. `feat(books): add Sirach alias` → type `feat`, message `add Sirach alias`.
+2. Check for `!` after the type or `BREAKING CHANGE` in the full commit body — if present, mark as breaking.
+3. Map the type to a section using the table above.
+4. Skip commits that map to *(skip)*.
+5. Format each entry as `- {message}` (sentence-case, no trailing period).
+6. Prefix breaking entries: `- **BREAKING:** {message}`.
+
+Build a map of section → list of entries. Only include sections that have at least one entry.
+
+Section order in output: Added, Changed, Deprecated, Removed, Fixed, Security.
+
+---
+
+## Step 6 — Bootstrap CHANGELOG.md if Missing
+
+If `CHANGELOG.md` does not exist at the project root, create it:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+<!-- comparison links — maintained automatically by the changelog skill -->
+```
+
+---
+
+## Step 7 — Build the New Release Section
+
+Construct the versioned entry block:
+
+```markdown
+## [{VERSION}] - {DATE}
+
+### Added
+- entry one
+- entry two
+
+### Fixed
+- entry three
+```
+
+Only include section headings that have entries. If `COMMITS` is empty (no user-facing changes),
+add a single entry under Changed:
+
+```markdown
+### Changed
+- Internal maintenance and dependency updates
+```
+
+---
+
+## Step 8 — Update CHANGELOG.md
+
+Read the current `CHANGELOG.md`. Apply these edits in order:
+
+1. **Replace the `## [Unreleased]` block** — remove all content between `## [Unreleased]` and
+   the next `## [` heading (or end of file before the links section). Insert the new versioned
+   release section in its place.
+
+2. **Re-insert a blank `## [Unreleased]` section** above the new versioned section:
+
+   ```markdown
+   ## [Unreleased]
+
+   ## [{VERSION}] - {DATE}
+   ...
+   ```
+
+3. **Update or create comparison links** at the bottom of the file. The links section sits below
+   all versioned entries. Maintain this structure:
+
+   ```markdown
+   [Unreleased]: {REPO_URL}/compare/v{VERSION}...HEAD
+   [{VERSION}]: {REPO_URL}/compare/v{PREV_TAG}...v{VERSION}
+   [{PREV_TAG}]: ...
+   ```
+
+   Where `PREV_TAG` is `LAST_TAG` (without a leading `v` added twice — match the existing tag
+   format in the repo). If there is no previous tag, the first versioned link uses the first
+   commit SHA:
+
+   ```markdown
+   [{VERSION}]: {REPO_URL}/commits/v{VERSION}
+   ```
+
+Write the updated content back to `CHANGELOG.md`.
+
+---
+
+## Step 8b — Apply History Threshold (optional)
+
+Only runs when `MAX_FULL_ENTRIES` was supplied.
+
+Count the versioned entries in the file (every `## [X.Y.Z]` heading that is not `## [Unreleased]`).
+If the count exceeds `MAX_FULL_ENTRIES`, collapse the oldest entries down to links-only:
+
+**Before (full entry):**
+```markdown
+## [0.1.0] - 2026-01-15
+
+### Added
+- Initial release with bible_enrich_markdown tool
+```
+
+**After (links-only):**
+```markdown
+## [0.1.0] - 2026-01-15
+
+*See the [0.1.0 comparison](comparison-link) for details.*
+```
+
+Rules:
+- Collapse from the oldest entry upward until the count of full entries equals `MAX_FULL_ENTRIES`.
+- The newest `MAX_FULL_ENTRIES` entries always remain in full.
+- Never collapse `[Unreleased]`.
+- The comparison link at the bottom is always preserved regardless of threshold.
+- If the file already has links-only entries and the count of full entries is within the threshold,
+  do nothing — do not re-expand collapsed entries.
+
+---
+
+## Step 9 — Report
+
+Print:
+
+```
+CHANGELOG.md updated
+  Version:       {VERSION}
+  Date:          {DATE}
+  Sections:      {comma-separated list of sections written, e.g. "Added, Fixed"}
+  Commits:       {N} user-facing commits included ({M} skipped as internal)
+  Links:         comparison links updated
+  Collapsed:     {K} old entries reduced to links-only  (omit line if K = 0)
+```
+
+Return control to the calling skill (e.g. `release`) without creating a git commit —
+committing is the responsibility of the caller.
+
+---
+
+## Behavioral Rules
+
+- Never commit or stage files — the caller is responsible for that.
+- Never invent entries not present in the git log.
+- Never remove existing versioned entries from the changelog.
+- If `CHANGELOG.md` already contains an entry for `VERSION`, stop:
+  > "CHANGELOG.md already has an entry for {VERSION}. Bump the version or edit the file manually."
+- Preserve any manually written content in the `## [Unreleased]` section by including it in the
+  new versioned entry before the auto-generated entries (manual entries first, then git-derived).
+- Never re-expand a previously collapsed (links-only) entry, even if `MAX_FULL_ENTRIES` is raised.
+- When `MAX_FULL_ENTRIES` is not supplied, never collapse any entries — the default is no limit.

--- a/.claude/skills/complete-a-release/SKILL.md
+++ b/.claude/skills/complete-a-release/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: complete-a-release
+description: >
+  Completes a release after the release PR has been merged. Verifies the default
+  branch contains the correct version bump, creates and pushes a git tag, then
+  creates a GitHub release using the changelog entry as release notes.
+  Invoked explicitly as /complete-a-release <version> (e.g. /complete-a-release 0.3.0).
+  Must be run after /start-a-release <version> and after the release PR is merged.
+  Do not trigger on general conversation — only activate on an explicit invocation
+  with a version argument.
+---
+
+# Complete a Release
+
+## Usage
+
+```
+/complete-a-release <version>
+```
+
+Examples:
+```
+/complete-a-release 0.3.0
+/complete-a-release 1.0.0
+```
+
+Arguments:
+- `VERSION` — required. The version being released. Must match what was used in
+  `/start-a-release <version>`.
+
+---
+
+## Step 1 — Parse the Version Argument
+
+Extract `VERSION` from the argument. If missing or not a valid semver string, stop:
+
+> "Usage: /complete-a-release <version>
+> Example: /complete-a-release 0.3.0
+> This must match the version passed to /start-a-release."
+
+---
+
+## Step 2 — Environment Pre-flight
+
+Run in parallel:
+
+```bash
+# A1: detect default branch
+git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+
+# A2: current branch
+git branch --show-current
+
+# A3: working tree status
+git status --porcelain
+
+# A4: fetch and check commits behind
+git fetch origin --quiet
+git rev-list HEAD..origin/{DEFAULT_BRANCH} --count 2>/dev/null || echo "0"
+```
+
+Present a pre-flight checklist:
+
+```
+Pre-flight for completing release {VERSION}
+────────────────────────────────────────────
+[✓ or ✗] On default branch    current: {CURRENT_BRANCH}  required: {DEFAULT_BRANCH}
+[✓ or ✗] Working tree clean   {N modified/staged files, or "clean"}
+[✓ or ✗] Up to date           {N commits behind origin/{DEFAULT_BRANCH}, or "up to date"}
+```
+
+**If `CURRENT_BRANCH` != `DEFAULT_BRANCH`**, stop:
+
+> "You must be on `{DEFAULT_BRANCH}` to complete a release. The release PR must be merged
+> before running this command."
+
+**If working tree has modified or staged files**, stop:
+
+> "Your working tree has modified or staged files. This command should only be run on a
+> clean checkout of `{DEFAULT_BRANCH}` after merging the release PR."
+
+**If `COMMITS_BEHIND` > 0**, stop:
+
+> "{COMMITS_BEHIND} commit(s) behind origin/{DEFAULT_BRANCH}. Run `git pull` first — you
+> need the merged release PR commit locally before tagging."
+
+---
+
+## Step 3 — Verify the Release PR Was Merged
+
+Read the version from `package.json`:
+
+```bash
+node -e "const p = JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log(p.version)"
+```
+
+Store as `PACKAGE_VERSION`. If `PACKAGE_VERSION` != `VERSION`, stop:
+
+> "package.json version is {PACKAGE_VERSION}, not {VERSION}.
+> Has the release PR for {VERSION} been merged? Check that the correct PR was merged
+> into {DEFAULT_BRANCH} before running this command."
+
+Verify `CHANGELOG.md` contains a `## [{VERSION}]` entry:
+
+```bash
+grep -c "## \[{VERSION}\]" CHANGELOG.md
+```
+
+If the entry is missing, stop:
+
+> "CHANGELOG.md does not have an entry for [{VERSION}].
+> The release PR may not have been merged, or the changelog was not updated correctly."
+
+---
+
+## Step 4 — Check the Tag Does Not Already Exist
+
+```bash
+git tag --list v{VERSION}
+```
+
+If the tag already exists locally, stop:
+
+> "Tag `v{VERSION}` already exists locally. Has this release already been completed?"
+
+```bash
+git ls-remote --tags origin v{VERSION}
+```
+
+If the tag already exists on the remote, stop:
+
+> "Tag `v{VERSION}` already exists on origin. This release may have already been published."
+
+---
+
+## Step 5 — Extract Release Notes from CHANGELOG.md
+
+Read `CHANGELOG.md` and extract the body of the `## [{VERSION}]` entry — everything between
+the `## [{VERSION}]` heading and the next `## [` heading (or the comparison links section).
+
+Store as `RELEASE_NOTES`. This will be used as the GitHub release body.
+
+If extraction fails or the entry body is empty, use a fallback:
+
+```
+See CHANGELOG.md for details.
+```
+
+---
+
+## Step 6 — Confirm Before Tagging
+
+Show the user exactly what will happen:
+
+```
+Ready to complete release v{VERSION}
+──────────────────────────────────────────────────────────
+Tag:       v{VERSION}  →  {SHORT_SHA} ("{latest commit subject}")
+Push:      git push origin v{VERSION}
+Release:   GitHub release "v{VERSION}" created from tag
+
+Release notes preview:
+{first 10 lines of RELEASE_NOTES}
+...
+```
+
+Ask:
+
+> "Shall I proceed? This will create and push the tag and open a GitHub release. (yes / cancel)"
+
+Wait for explicit confirmation. This is the last gate before irreversible actions.
+
+---
+
+## Step 7 — Create the Git Tag
+
+```bash
+git tag -a v{VERSION} -m "Release v{VERSION}"
+```
+
+If this fails, stop and report the error. Do not attempt to push.
+
+---
+
+## Step 8 — Push the Tag
+
+```bash
+git push origin v{VERSION}
+```
+
+If the push fails, stop:
+
+> "Tag was created locally but push failed.
+> Error: {error message}
+> You can retry with: git push origin v{VERSION}"
+
+Do not attempt to create the GitHub release if the push failed — the tag must be on the
+remote before the release is created against it.
+
+---
+
+## Step 9 — Create the GitHub Release
+
+Use the `gh` CLI:
+
+```bash
+gh release create v{VERSION} \
+  --title "v{VERSION}" \
+  --notes "{RELEASE_NOTES}"
+```
+
+Add `--prerelease` if `VERSION` contains a pre-release identifier (e.g. `-beta`, `-rc`, `-alpha`).
+
+Store the returned release URL as `RELEASE_URL`.
+
+---
+
+## Step 10 — Report
+
+```
+Release v{VERSION} complete
+──────────────────────────────────────────────────────────
+Tag:      v{VERSION}  (pushed to origin)
+Release:  {RELEASE_URL}
+
+The release branch release/v{VERSION} can now be deleted:
+  git branch -d release/v{VERSION}
+  git push origin --delete release/v{VERSION}
+```
+
+Do not delete the release branch automatically — leave that to the user.
+
+---
+
+## Behavioral Rules
+
+- Never run unless on the default branch with a clean, up-to-date working tree.
+- Never create the tag before verifying `package.json` and `CHANGELOG.md` both reflect `VERSION`.
+- Never push the tag unless `git tag` succeeded cleanly.
+- Never create the GitHub release unless the tag push succeeded.
+- Never run `npm publish`.
+- If the GitHub release creation fails after the tag is pushed, report clearly:
+  > "Tag v{VERSION} was pushed successfully. GitHub release creation failed: {error}.
+  > You can create the release manually at: {REPO_URL}/releases/new?tag=v{VERSION}"
+- Mark the release as prerelease automatically when VERSION contains `-beta`, `-rc`, `-alpha`,
+  or any other pre-release identifier per semver spec.

--- a/.claude/skills/start-a-release/SKILL.md
+++ b/.claude/skills/start-a-release/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: start-a-release
+description: >
+  Opens a release PR for a given version. Validates the environment, cuts a
+  release/v{VERSION} branch from the default branch, bumps package.json, updates
+  CHANGELOG.md via the changelog skill, commits, pushes, and opens a PR to main.
+  Invoked explicitly as /start-a-release <version> (e.g. /start-a-release 0.3.0).
+  Do not trigger on general conversation about releases — only activate on an
+  explicit invocation with a version argument.
+---
+
+# Start a Release
+
+## Usage
+
+```
+/start-a-release <version>
+```
+
+Examples:
+```
+/start-a-release 0.3.0
+/start-a-release 1.0.0
+/start-a-release 2.1.0-beta.1
+```
+
+Arguments:
+- `VERSION` — required. Target semantic version string, e.g. `0.3.0`.
+
+---
+
+## Step 1 — Parse and Validate the Version Argument
+
+Extract `VERSION` from the argument. If missing or not a valid semver string, stop:
+
+> "Usage: /start-a-release <version>
+> Example: /start-a-release 0.3.0
+> Version must be a valid semantic version (MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-prerelease)."
+
+Read the current version from `package.json`:
+
+```bash
+node -e "const p = JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log(p.version)"
+```
+
+Store as `CURRENT_VERSION`. Compare `VERSION` against `CURRENT_VERSION` using semver ordering.
+If `VERSION` is not strictly greater than `CURRENT_VERSION`, stop:
+
+> "VERSION {VERSION} is not greater than the current version {CURRENT_VERSION}.
+> Choose a higher version number."
+
+---
+
+## Step 2 — Environment Pre-flight
+
+Run in parallel:
+
+```bash
+# A1: detect default branch
+git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+
+# A2: current branch
+git branch --show-current
+
+# A3: working tree status
+git status --porcelain
+
+# A4: commits behind origin default branch
+git fetch origin --quiet
+git rev-list HEAD..origin/{DEFAULT_BRANCH} --count 2>/dev/null || echo "0"
+```
+
+**Split A3 output into:**
+- `DIRTY_FILES` — lines where first two chars include `M`, `A`, `D`, `R`, `C`, `U`
+- `UNTRACKED_FILES` — lines starting with `??`
+
+Present a pre-flight checklist:
+
+```
+Pre-flight for release {VERSION}
+─────────────────────────────────
+[✓ or ✗] On default branch    current: {CURRENT_BRANCH}  required: {DEFAULT_BRANCH}
+[✓ or ✗] Working tree clean   {N modified/staged files, or "clean"}
+[✓ or ✗] Up to date           {N commits behind, or "up to date"}
+```
+
+**If `CURRENT_BRANCH` != `DEFAULT_BRANCH`**, stop:
+
+> "You must be on `{DEFAULT_BRANCH}` to start a release. Switch branches and try again."
+
+**If `DIRTY_FILES` is non-empty**, stop:
+
+> "Your working tree has modified or staged files. Commit or stash them first.
+> {list each dirty file}"
+
+**If `COMMITS_BEHIND` > 0**, stop:
+
+> "{COMMITS_BEHIND} commit(s) behind origin/{DEFAULT_BRANCH}. Run `git pull` first."
+
+**If `UNTRACKED_FILES` is non-empty**, list them and ask:
+
+> "Untracked files found:
+>     {list each}
+> These will follow onto the release branch. Continue? (yes / abort)"
+
+Wait for confirmation. If abort, stop.
+
+---
+
+## Step 3 — Confirm the Release Plan
+
+Show the user exactly what will happen:
+
+```
+Release plan for v{VERSION}
+───────────────────────────────────────────────
+Current version:  {CURRENT_VERSION}
+Target version:   {VERSION}
+Release branch:   release/v{VERSION}  (new, from {DEFAULT_BRANCH})
+
+Actions:
+  1. git checkout -b release/v{VERSION}
+  2. Bump version in package.json  {CURRENT_VERSION} → {VERSION}
+  3. Run /changelog {VERSION}  (update CHANGELOG.md)
+  4. git add package.json CHANGELOG.md
+  5. git commit -m "chore: release {VERSION}"
+  6. git push origin release/v{VERSION}
+  7. Open PR:  release/v{VERSION} → {DEFAULT_BRANCH}
+```
+
+Ask:
+
+> "Shall I proceed? (yes / cancel)"
+
+Wait for explicit confirmation before continuing.
+
+---
+
+## Step 4 — Create the Release Branch
+
+Check if the branch already exists:
+
+```bash
+git branch --list release/v{VERSION}
+```
+
+If it exists locally, stop:
+
+> "Branch `release/v{VERSION}` already exists. Delete it or choose a different version."
+
+Check if it exists on the remote:
+
+```bash
+git ls-remote --heads origin release/v{VERSION}
+```
+
+If it exists on the remote, stop with the same message.
+
+Otherwise:
+
+```bash
+git checkout -b release/v{VERSION}
+```
+
+---
+
+## Step 5 — Bump the Version in package.json
+
+Read `package.json`, update the `"version"` field to `VERSION`, and write it back.
+Preserve all other content and formatting exactly — do not reformat the file.
+
+Verify the change:
+
+```bash
+node -e "const p = JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log(p.version)"
+```
+
+Confirm it prints `{VERSION}`. If not, stop and report the error.
+
+---
+
+## Step 6 — Update CHANGELOG.md
+
+Call the `changelog` skill:
+
+```
+/changelog {VERSION}
+```
+
+The changelog skill will:
+- Collect commits since the last git tag
+- Categorise them into Keep a Changelog sections
+- Cut a new `## [{VERSION}] - {DATE}` entry
+- Update the comparison links at the bottom
+
+After the skill completes, read the new `## [{VERSION}]` entry from `CHANGELOG.md` and store it
+as `RELEASE_NOTES` — it will be used as the PR body and later as the GitHub release notes.
+
+---
+
+## Step 7 — Commit the Changes
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "chore: release {VERSION}"
+```
+
+If the commit fails, stop and report the error. Do not proceed to push.
+
+---
+
+## Step 8 — Push the Branch
+
+```bash
+git push origin release/v{VERSION}
+```
+
+If the push fails (e.g. auth error, remote rejects), stop and report:
+
+> "Push failed. Check your remote access and try again.
+> Error: {error message}"
+
+---
+
+## Step 9 — Open the Pull Request
+
+**If MCP GitHub tools are available**, use `mcp__github__create_pull_request`:
+- title: `chore: release {VERSION}`
+- base: `{DEFAULT_BRANCH}`
+- head: `release/v{VERSION}`
+- body: the `RELEASE_NOTES` captured in Step 6, prefixed with:
+
+```markdown
+## Release v{VERSION}
+
+This PR bumps the version and updates the changelog for release v{VERSION}.
+Merge this PR, then run `/complete-a-release {VERSION}` to tag and publish the release.
+
+---
+
+{RELEASE_NOTES}
+```
+
+**If only `gh` CLI is available**:
+
+```bash
+gh pr create \
+  --title "chore: release {VERSION}" \
+  --base {DEFAULT_BRANCH} \
+  --head release/v{VERSION} \
+  --body "$(cat <<'EOF'
+## Release v{VERSION}
+...
+EOF
+)"
+```
+
+Store the returned PR URL as `PR_URL`.
+
+---
+
+## Step 10 — Report
+
+```
+Release v{VERSION} started
+──────────────────────────────────────────────────────
+Branch:   release/v{VERSION}
+PR:       {PR_URL}
+
+Next steps:
+  1. Review the PR and confirm the changelog entry looks correct
+  2. Merge the PR into {DEFAULT_BRANCH}
+  3. Run /complete-a-release {VERSION}
+```
+
+---
+
+## Behavioral Rules
+
+- Never create a tag or push a tag — that is `complete-a-release`'s responsibility.
+- Never touch `{DEFAULT_BRANCH}` directly — all changes go via the release branch and PR.
+- If any step after branch creation fails, leave the branch and any committed changes in place;
+  do not attempt to clean up. Report the failure clearly and tell the user which step failed.
+- Never run `npm publish`.

--- a/.claude/skills/start-work-on-an-issue/SKILL.md
+++ b/.claude/skills/start-work-on-an-issue/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: start-work-on-an-issue
+description: >
+  Sets up a local git branch to begin work on a GitHub issue: verifies the environment
+  is clean, fetches issue details, assigns the issue to the current user, derives a
+  typed branch name, and creates the branch. Invoked explicitly with
+  `/start-work-on-an-issue <issue-number>` or
+  `/start-work-on-an-issue <github-issue-url>`. Do not trigger on general conversation
+  about issues — only activate on an explicit invocation with a number or URL argument.
+---
+
+# Start Work on an Issue
+
+## Usage
+
+```
+/start-work-on-an-issue <number>
+/start-work-on-an-issue <github-issue-url>
+```
+
+Examples:
+```
+/start-work-on-an-issue 42
+/start-work-on-an-issue https://github.com/psenger/mcp-markdown-bible-enricher/issues/42
+```
+
+---
+
+## Starting Gate
+
+The starting gate runs in two phases: **inspect** (read-only, no confirmation needed) then **act** (explain what will change and ask the user to confirm before running anything).
+
+---
+
+### Phase A — Inspect
+
+**A1 must run first** — its result (`DEFAULT_BRANCH`) is required by A4. Once A1 completes, run A2, A3, and A4 in parallel.
+
+```bash
+# A1: detect the default branch (run first)
+git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+```
+
+Store as `DEFAULT_BRANCH`. If the remote is unreachable, fall back to checking for a local `main` then `master`.
+
+Then run in parallel:
+
+```bash
+# A2: find the current branch
+git branch --show-current
+
+# A3: check for uncommitted changes, staged files, AND untracked files
+git status --porcelain
+
+# A4: check how far local is behind the remote default branch
+git rev-list HEAD..origin/{DEFAULT_BRANCH} --count 2>/dev/null || echo "0"
+```
+
+From the `git status --porcelain` output, split into two buckets:
+- `DIRTY_FILES` — lines where the first two characters include `M`, `A`, `D`, `R`, `C`, or `U` (modified or staged)
+- `UNTRACKED_FILES` — lines starting with `??`
+
+Store results: `DEFAULT_BRANCH`, `CURRENT_BRANCH`, `DIRTY_FILES` (list or empty), `UNTRACKED_FILES` (list or empty), `COMMITS_BEHIND` (number).
+
+---
+
+### Phase B — Report and Confirm
+
+Present a pre-flight summary to the user. Use a checklist format so the state is immediately scannable:
+
+```
+Starting gate for issue #{number}
+──────────────────────────────────
+[✓ or ✗] On default branch    current: {CURRENT_BRANCH}  required: {DEFAULT_BRANCH}
+[✓ or ✗] Working tree clean   {N modified/staged files, or "clean"}
+[✓ or ✗] Untracked files      {N untracked files found, or "none"}
+[✓ or ✗] Up to date           {N commits behind origin/{DEFAULT_BRANCH}, or "up to date"}
+```
+
+**If `DIRTY_FILES` is non-empty**, do not list any actions. Stop with:
+
+> "Your working tree has modified or staged files. Stash or commit them before I can continue."
+> ```
+> {list each dirty file}
+> ```
+
+**If `UNTRACKED_FILES` is non-empty**, list them and ask how to proceed before continuing:
+
+> ```
+> Untracked files:
+>     {list each untracked file}
+>
+> These files are not tracked by git. They will follow you onto the new branch
+> and won't affect the checkout, but you may want to handle them first.
+>
+> How do you want to proceed?
+>   a) Leave them — continue, I won't touch them
+>   b) Nuke it    — run `nuke` in your terminal first, then come back
+>   c) Abort      — I'll stop here so you can handle them yourself
+> ```
+
+Wait for the user's choice before continuing:
+- **a)** proceed to the actions list below
+- **b)** stop — do not continue until the user returns and confirms the tree is clean
+- **c)** stop
+
+**Note:** Claude never runs `nuke` itself. The `nuke` shell function is a user-side tool that previews all deletions and requires the user to type `"nuke"` to confirm. It resets the working tree to `origin/{DEFAULT_BRANCH}`.
+
+**If both `DIRTY_FILES` and `UNTRACKED_FILES` are empty**, list the planned actions:
+
+```
+Actions I will take:
+  1. git checkout {DEFAULT_BRANCH}
+     — switches to the default branch so the new branch is cut from the right base
+     (skipped if already on {DEFAULT_BRANCH})
+
+  2. git fetch origin
+     — downloads latest remote refs without changing any local files
+
+  3. git pull origin {DEFAULT_BRANCH}
+     — fast-forwards local {DEFAULT_BRANCH} to match the remote
+     (skipped if already up to date)
+```
+
+Then ask:
+
+> "Does this look right? Type **yes** to run the above, or tell me if something needs adjusting."
+
+Wait for explicit confirmation before proceeding to Phase C.
+
+---
+
+### Phase C — Execute
+
+Run only the actions that are actually needed (skip steps that are already satisfied):
+
+```bash
+# Only if CURRENT_BRANCH != DEFAULT_BRANCH
+git checkout {DEFAULT_BRANCH}
+
+# Always
+git fetch origin
+
+# Only if COMMITS_BEHIND > 0
+git pull origin {DEFAULT_BRANCH}
+```
+
+After each command, check for errors. If `git pull` produces merge conflicts, stop:
+
+> "Pull resulted in merge conflicts. Resolve them and run `git merge --continue`, then try again."
+
+On success, confirm to the user:
+
+> "Environment ready. On `{DEFAULT_BRANCH}`, up to date with origin."
+
+Then proceed to Step 0.
+
+---
+
+## Step 0 — Detect Tooling
+
+Check what GitHub access is available. Try in this order:
+
+1. **GitHub MCP server** — look for `mcp__github__` tools in the current session. If present, use them for issue lookup and assignment.
+2. **`gh` CLI** — run `command -v gh && gh auth status`. If authenticated, use it.
+3. If neither is available, tell the user and stop.
+
+Set `USE_MCP` or `USE_GH` accordingly.
+
+---
+
+## Step 1 — Parse the Issue Number
+
+The skill is invoked explicitly. The argument is either a bare number or a GitHub issue URL.
+
+**Bare number** — `42` or `#42`:
+- Strip the leading `#` if present and use the integer directly.
+
+**GitHub issue URL** — `https://github.com/{owner}/{repo}/issues/{number}`:
+- Extract the trailing integer from the path.
+- Note the `{owner}/{repo}` for use in Step 2 (overrides the value derived from `git remote`).
+
+If the argument is missing or cannot be parsed, stop:
+
+> "Please provide an issue number or GitHub issue URL, e.g.:
+> `/start-work-on-an-issue 42`
+> `/start-work-on-an-issue https://github.com/psenger/mcp-markdown-bible-enricher/issues/42`"
+
+---
+
+## Step 2 — Fetch Issue Details
+
+**If USE_MCP:** call `mcp__github__issue_read` with the repo owner/name from `git remote get-url origin`.
+
+**If USE_GH:**
+```bash
+gh issue view <number> --json number,title,body,labels,assignees
+```
+
+Capture: `number`, `title`, `body`, `labels` (array of label names), `assignees`.
+
+---
+
+## Step 3 — Assign to Self
+
+Assign the issue to the authenticated user automatically (no confirmation needed).
+
+**If USE_MCP:** use `mcp__github__issue_write` to add the current user as assignee.
+
+**If USE_GH:**
+```bash
+gh issue edit <number> --add-assignee @me
+```
+
+If this fails, note it but continue — don't block on assignment errors.
+
+---
+
+## Step 4 — Derive Branch Name
+
+### Branch type reference
+
+| Branch type prefix | Meaning |
+|---|---|
+| `feat` | New feature or enhancement |
+| `fix` | Bug fix |
+| `docs` | Documentation-only change |
+| `chore` | Dependency update or maintenance task |
+
+### Type from labels
+
+Map issue labels to a branch type prefix using this priority order (first match wins):
+
+| Label (case-insensitive) | Branch type |
+|---|---|
+| `bug` | `fix` |
+| `enhancement`, `feature` | `feat` |
+| `documentation`, `docs` | `docs` |
+| `dependencies`, `chore` | `chore` |
+| *(no match or no labels)* | `feat` |
+
+### Slug from title
+
+Transform the issue title:
+1. Lowercase
+2. Replace any character that is not `a-z`, `0-9`, or `-` with a hyphen
+3. Collapse consecutive hyphens into one
+4. Strip leading and trailing hyphens
+5. Truncate to 50 characters, cutting at a hyphen boundary if possible
+
+### Final branch name
+
+```
+{type}/{number}-{slug}
+```
+
+Example: issue #29 "feat: make project agentic — add CHANGELOG..." with label `enhancement` →
+`feat/29-feat-make-project-agentic-add-changelog`
+
+---
+
+## Step 5 — Preview and Confirm
+
+Before touching GitHub or git, show the user exactly what will happen:
+
+```
+Ready to start work on issue #{number}
+──────────────────────────────────────
+Issue:   {title}
+Branch:  {branch-name}  (new, from {DEFAULT_BRANCH})
+Assign:  @{current-user}
+
+Actions:
+  1. Assign issue #{number} to @{current-user} on GitHub
+  2. git checkout -b {branch-name}
+```
+
+Ask:
+
+> "Shall I proceed? (yes / adjust branch name / cancel)"
+
+- **yes** — continue
+- **adjust branch name** — let the user provide a name, then re-display the summary
+- **cancel** — stop, do nothing
+
+---
+
+## Step 6 — Create the Git Branch
+
+Check if the branch already exists:
+```bash
+git branch --list {branch-name}
+```
+
+If it already exists, stop and ask:
+
+> "Branch `{branch-name}` already exists. Check it out, or would you like to use a different name?"
+
+Otherwise:
+```bash
+git checkout -b {branch-name}
+```
+
+Confirm the active branch with `git branch --show-current`. If the checkout fails for any reason, the spec files that were just written should be left in place — they are still useful and can be picked up on the next attempt.
+
+---
+
+## Step 7 — Report Back
+
+Print a summary:
+
+```
+Branch:   {branch-name}
+Issue:    #{number} — {title}
+Assigned: yes / skipped (reason)
+```
+
+Then say: "You're on `{branch-name}`. Ready to start."
+
+---
+
+## Behavioral Rules
+
+- Never touch GitHub or git before the user confirms in Step 5.
+- Never invent issue content — derive the branch type and slug solely from the fetched labels and title.
+- Never run `nuke` or any destructive cleanup command. If the working tree needs a hard reset, point the user to the `nuke` shell function and wait for them to return.
+- If branch creation fails after assignment has already been made, leave the assignment in place — the user is still the owner of the issue.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Something is not being enriched correctly, or the server is behaving unexpectedly
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+<!-- Describe the problem clearly. -->
+
+## Input
+
+<!-- Paste the exact Markdown text that produced the wrong output. -->
+
+```markdown
+
+```
+
+## Expected output
+
+<!-- What should the enriched text look like? -->
+
+```markdown
+
+```
+
+## Actual output
+
+<!-- What did you actually get? -->
+
+```markdown
+
+```
+
+## Environment
+
+- Server version: <!-- e.g. 0.2.3 — check package.json -->
+- MCP client: <!-- Claude Desktop / Claude Code / Cursor / other -->
+- `BIBLE_VERSION` env var: <!-- e.g. NRSVCE, or "default" if not set -->
+- `OBSIDIAN_FORMAT` env var: <!-- e.g. default, or your custom format -->
+- `INCLUDE_OBSIDIAN_LINKS` env var: <!-- true / false / default -->
+- Node.js version: <!-- node --version -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/psenger/mcp-markdown-bible-enricher/discussions
+    about: For general questions, use GitHub Discussions rather than opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest a new reference pattern, book alias, configuration option, or other improvement
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## What problem does this solve?
+
+<!-- Describe the use case. What are you trying to do that you can't do today? -->
+
+## Proposed behaviour
+
+<!-- Describe what you'd like to happen. If it's a new reference pattern, include example input and expected output. -->
+
+**Input:**
+```markdown
+
+```
+
+**Expected output:**
+```markdown
+
+```
+
+## Alternatives considered
+
+<!-- Have you tried working around this? Is there another approach that could solve it? -->
+
+## Additional context
+
+<!-- Any other relevant information — links to Bible Gateway pages, Obsidian vault structure, related issues, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Linked issue
+
+Closes #<!-- issue number -->
+
+<!-- Every PR must link to an issue. PRs without a linked issue may be closed without review. -->
+
+## What changed and why
+
+<!-- Summarise the change. Explain the why, not just the what — the diff shows the what. -->
+
+## Test plan
+
+<!-- How did you verify this works? Include the input text and enriched output for any new or changed patterns. -->
+
+**Input:**
+```markdown
+
+```
+
+**Output:**
+```markdown
+
+```
+
+## Checklist
+
+- [ ] `npm test` passes with no failures
+- [ ] New or changed regex patterns tested against complex multi-verse references
+- [ ] If a new book or alias was added, `BOOK_MAP` key is lowercase and `lookupBook()` resolves it correctly
+- [ ] If the enrichment pipeline changed, pass ordering was not altered without updating `agent-os/standards/enrichment/three-pass-ordering`
+- [ ] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
+
+---
+
+*PR review and merge is handled by the maintainer. Please do not merge your own PR.*

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-./.claude
+.claude/settings.local.json
+!.claude/skills/
 ./.idea
 .cache
 .cache/
@@ -57,7 +58,6 @@
 /yarn-error.log*
 bower_components
 build/Release
-CLAUDE.md
 coverage
 dist
 jspm_packages/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.3] - 2026-03-19
+
+### Added
+- YAML frontmatter protection — `enrichMarkdown()` now strips the frontmatter block before processing and reattaches it unchanged, preventing enrichment of metadata fields
+
+## [0.2.2] - 2026-03-18
+
+### Changed
+- Updated README with Obsidian integration guide, corrected `claude mcp add` command syntax, and removed stale limitations
+
+## [0.2.1] - 2026-03-18
+
+### Fixed
+- Over-broad lookahead `(?![:.\d])` in passes 2b and 2c replaced with `(?!\d)` — references followed by periods, colons, or ellipses are now correctly enriched (issue #11)
+
+## [0.2.0] - 2026-03-18
+
+### Added
+- Bare verse references for single-chapter books: `Jude 9`, `Obadiah 21`, `Philemon 25`, `2 John 1`, `3 John 14`
+- Bare chapter references: `Psalm 91`, `Isaiah 53`, `1 Corinthians 13`
+
+## [0.1.0] - 2026-03-18
+
+### Security
+- Bumped minimatch 3.1.2 → 3.1.5 / 9.0.5 → 9.0.9 (ReDoS fix)
+- Bumped `@hono/node-server` 1.19.9 → 1.19.11 (auth bypass fix, GHSA-wc8c-qw6v-h7f6)
+- Bumped `ajv` 6.12.6 → 6.14.0 (CVE-2025 `$data` regex exploit)
+- Bumped `hono` 4.11.9 → 4.12.8 (ReDoS and prototype pollution)
+- Bumped `express-rate-limit` 8.2.1 → 8.3.1 (security hardening)
+
+## [0.0.2] - 2026-03-18
+
+### Added
+- `agent-os/` directory with machine-readable standards and configuration for agentic workflows
+
+## [0.0.1] - 2026-02-10
+
+### Added
+- Initial release: MCP server with `bible_enrich_markdown` and `bible_enrich_file` tools
+- Bible Gateway link generation for all 73 Catholic Bible books (including 7 deuterocanonical books: Tobit, Judith, Wisdom, Sirach, Baruch, 1-2 Maccabees)
+- Obsidian wiki-link generation with configurable format template
+- Catechism of the Catholic Church (CCC) reference linking via Catholic Cross Reference
+- Environment variable configuration: `BIBLE_VERSION`, `OBSIDIAN_FORMAT`, `INCLUDE_OBSIDIAN_LINKS`
+
+[Unreleased]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.0.2...v0.1.0
+[0.0.2]: https://github.com/psenger/mcp-markdown-bible-enricher/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/psenger/mcp-markdown-bible-enricher/commits/v0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,172 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MCP server that enriches Markdown documents with:
+- **Bible Gateway links** (NRSVCE by default) for Bible references
+- **Obsidian wiki-links** for cross-referencing in Obsidian vaults
+- **Catholic Cross Reference links** for Catechism of the Catholic Church (CCC) references
+
+Supports all 73 books of the Catholic Bible, including the 7 deuterocanonical books (Tobit, Judith, Wisdom, Sirach, Baruch, 1-2 Maccabees). Enrichment is **deterministic** — regex-based, no LLM inference involved in the transformation.
+
+## Development Commands
+
+```bash
+npm run build          # compile TypeScript to dist/
+npm run dev            # watch mode (tsx)
+npm run inspect        # MCP Inspector browser GUI
+npm test               # run all unit tests
+npm run test:watch     # watch mode
+npm run test:coverage  # coverage report
+npm run lint           # ESLint
+npm run format         # Prettier (writes)
+npm run format:check   # Prettier (check only)
+npm run clean          # remove dist/
+```
+
+Run a single test file:
+```bash
+node --experimental-vm-modules node_modules/jest/bin/jest.js src/__tests__/enrichment.test.ts
+```
+
+Or by pattern:
+```bash
+npm test -- --testPathPattern="enrichment"
+```
+
+## Architecture
+
+### Entry point: `src/index.ts`
+
+Creates an MCP server using `@modelcontextprotocol/sdk` with stdio transport. Registers:
+- **Tools**: `bible_enrich_markdown` (string → string), `bible_enrich_file` (file path → file)
+- **Prompts**: `bible_enrich_document` (instructs Claude to call the tool), `help` (inline docs)
+
+### Core logic: `src/enrichment.ts`
+
+`enrichMarkdown()` is the single exported function. It strips YAML frontmatter first (reattaches it unchanged at the end), then applies **five sequential regex passes** to the body:
+
+| Pass | Regex | Handles |
+|---|---|---|
+| 1 | `BACKTICK_BIBLE_RE` | Backtick-wrapped refs like `` `1 Samuel 16:1:` `` — unwraps then enriches |
+| 2 | `BIBLE_REF_RE` | Plain-text `chapter:verse` refs not already inside a Markdown link |
+| 2b | `SINGLE_CHAPTER_REF_RE` | Bare-verse refs for single-chapter books: `Jude 9`, `Obadiah 21` |
+| 2c | `BARE_CHAPTER_REF_RE` | Chapter-only refs: `Isaiah 53`, `Psalm 91` |
+| 3 | `CCC_RE` | Catechism refs: `CCC 528`, `CCC 528-530, 610-612` |
+
+**Pass ordering is fixed and load-bearing.** Passes 2b and 2c run after pass 2 so that already-enriched text is protected by the negative lookbehind; pass 2c runs after 2b so single-chapter books aren't double-processed. See `agent-os/standards/enrichment/three-pass-ordering` for the rationale.
+
+**Idempotency guards:** every Bible regex uses a negative lookbehind for `[(` and a negative lookahead for `]()` to skip text already inside Markdown links.
+
+**Implicit chapter inheritance:** `parseChapterVerse()` propagates the last seen chapter across comma-separated groups, so `16:1, 4-13` produces chapter 16 for both groups.
+
+**Single-chapter book Obsidian format:** `Jude 9` → `[[Jude#v9]]` (no chapter digits); regular books → `[[Matt-05#v3]]`. The `singleChapter` flag on `BookInfo` controls this branch.
+
+### Book mapping: `src/books.ts`
+
+- `BOOK_MAP`: `Record<string, BookInfo>` keyed by **lowercase** book name. Values: `{ abbrev, singleChapter }`.
+- `SINGLE_CHAPTER_BOOKS`: derived string array used to build `SINGLE_CHAPTER_REF_RE`.
+- `lookupBook()`: case-insensitive lookup that normalises input to lowercase before accessing `BOOK_MAP`.
+
+Alternative names map to the same entry (e.g., `"ecclesiasticus"` and `"wisdom of ben sira"` both resolve to `Sir`).
+
+### Configuration: `src/config.ts`
+
+`loadConfig()` reads env vars once at **module initialisation** (top-level call in `enrichment.ts`). There is no way to change config at runtime — the server must restart. This has a direct consequence for tests: `process.env` changes in `beforeEach` do **not** affect `config` because the module is already initialised. Use `jest.resetModules()` and dynamic `import()` inside individual tests when you need to test different env configurations. See `agent-os/standards/testing/config-module-cache-limitation`.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `BIBLE_VERSION` | `NRSVCE` | Translation used in Bible Gateway URLs |
+| `OBSIDIAN_FORMAT` | `[[{abbrev}-{chapter2}#v{verse}]]` | Placeholders: `{abbrev}`, `{chapter}`, `{chapter2}`, `{verse}` |
+| `INCLUDE_OBSIDIAN_LINKS` | `true` | Only `"false"` disables; any other value enables |
+
+## TypeScript Configuration
+
+- ES Modules (`"type": "module"` in package.json)
+- Always use `.js` extensions in imports even though source files are `.ts` — required for Node16 module resolution
+- Compiles `src/` → `dist/`, target ES2022, strict mode
+
+## Regex Pattern Guidelines
+
+When modifying `BIBLE_REF_RE`, `SINGLE_CHAPTER_REF_RE`, or `BARE_CHAPTER_REF_RE`:
+
+- Test against complex patterns: `1 Samuel 16:1, 16:4-13`, `Matthew 2:1-6, 11-12`, `Jude 9-14`
+- Verify the negative lookbehind/lookahead still prevents matching inside existing `[text](url)` links
+- Run the enrichment tests after any change — they cover idempotency (enriching already-enriched output must produce no further changes)
+- `BOOK_NAMES` in `enrichment.ts` and `BOOK_MAP` in `books.ts` must stay in sync when adding new books or aliases
+
+## agent-os/ Directory
+
+Machine-readable specs and standards that capture design decisions not obvious from the code:
+
+```
+agent-os/
+├── specs/           # per-feature change specs (timestamped)
+└── standards/
+    ├── index.yml    # index of all standards with one-line descriptions
+    ├── books/       # BOOK_MAP key casing rules, abbrev sourcing, alternative name pattern
+    ├── config/      # config loading lifecycle, INCLUDE_OBSIDIAN_LINKS opt-out semantics
+    ├── enrichment/  # regex pass ordering, lookbehind guards, chapter inheritance
+    ├── global/      # cross-cutting principles
+    └── testing/     # Jest module cache limitation for config tests
+```
+
+Before changing the enrichment pipeline, book map, or config loading, read the relevant standard first. When proposing a new feature, create a spec under `agent-os/specs/` following the existing timestamp-slug naming convention.
+
+## Skills (slash commands)
+
+Four skills in `.claude/skills/` handle owner-operated workflows:
+
+| Skill | Invocation | Purpose |
+|---|---|---|
+| `start-work-on-an-issue` | `/start-work-on-an-issue <number>` | Checks out `main`, creates a typed branch, assigns the GitHub issue |
+| `changelog` | `/changelog <version> [date]` | Collects commits since the last tag and writes a versioned CHANGELOG entry |
+| `start-a-release` | `/start-a-release <version>` | Cuts a release branch, bumps `package.json`, runs `/changelog`, opens a PR |
+| `complete-a-release` | `/complete-a-release <version>` | After the release PR merges — creates the annotated tag and GitHub release |
+
+Release sequence: `/start-a-release` → merge the PR → `/complete-a-release`.
+
+Branches follow `{type}/{issue-number}-{slug}` (e.g. `feat/29-add-bare-chapter-refs`); `start-work-on-an-issue` derives this from issue labels and title automatically.
+
+## Commit Message Format
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer]
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`.
+
+Breaking changes: add `!` after the type (`feat!:`) or include `BREAKING CHANGE:` in the footer.
+
+Examples:
+
+```
+feat: add bare-verse support for single-chapter books
+fix: correct lookahead in SINGLE_CHAPTER_REF_RE
+docs: update Obsidian format examples in README
+chore: bump @modelcontextprotocol/sdk to 1.13.0
+feat!: change default OBSIDIAN_FORMAT placeholder syntax
+
+BREAKING CHANGE: {chap} renamed to {chapter2} in OBSIDIAN_FORMAT templates
+```
+
+Never add `Co-Authored-By` trailers.
+
+## Pull Request Format
+
+PRs must use the template at `.github/PULL_REQUEST_TEMPLATE.md`. Required sections:
+
+- **Linked issue** — every PR must close an issue (`Closes #N`)
+- **What changed and why** — explain the motivation, not just the diff
+- **Test plan** — include the exact input Markdown and expected enriched output for any new or changed patterns
+- **Checklist** — all boxes must be ticked before requesting review
+
+PR title should follow the same Conventional Commits format as commit messages. The maintainer (@psenger) handles review and merge — never merge your own PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,204 @@
+# Contributing
+
+Contributions are welcome. Please read this document before opening a PR.
+
+## Start with an issue
+
+**Open an issue before writing any code.** This gives the maintainer a chance to confirm
+the change is wanted, discuss the approach, and avoid wasted effort. PRs opened without a
+linked issue may be closed without review.
+
+- [Report a bug](https://github.com/psenger/mcp-markdown-bible-enricher/issues/new?template=bug_report.md)
+- [Request a feature](https://github.com/psenger/mcp-markdown-bible-enricher/issues/new?template=feature_request.md)
+- [Report a security vulnerability](./SECURITY.md) — do not use a public issue for security reports
+
+## Contribution workflow
+
+1. Open an issue and wait for a response before starting work
+2. Fork the repository
+3. Create a branch from `main`: `git checkout -b feat/123-short-description`
+4. Make your changes (see code conventions below)
+5. Ensure all tests pass: `npm test`
+6. Push to your fork and open a PR against `main`
+7. Fill in the PR template — link the issue your PR addresses
+
+**PR review and merge is handled by the maintainer (@psenger).** Do not merge your own PR.
+The maintainer may request changes, ask questions, or close the PR if it doesn't fit the
+project direction.
+
+## Development setup
+
+```bash
+git clone https://github.com/<your-fork>/mcp-markdown-bible-enricher.git
+cd mcp-markdown-bible-enricher
+npm install
+npm run build
+```
+
+Test interactively with the MCP Inspector:
+
+```bash
+npm run inspect
+```
+
+Watch mode during development:
+
+```bash
+npm run dev
+```
+
+## Running tests
+
+```bash
+npm test                    # all tests
+npm run test:watch          # watch mode
+npm run test:coverage       # coverage report
+
+# single file
+node --experimental-vm-modules node_modules/jest/bin/jest.js src/__tests__/enrichment.test.ts
+
+# by pattern
+npm test -- --testPathPattern="enrichment"
+```
+
+**Config module cache:** `loadConfig()` runs at module initialisation, so `process.env` changes
+in `beforeEach` do not affect it. Use `jest.resetModules()` and dynamic `import()` inside the
+test body when you need to test different env configurations. See
+`agent-os/standards/testing/config-module-cache-limitation`.
+
+## Agent OS workflow
+
+This project uses [Agent OS v3](https://buildermethods.com/agent-os) to manage coding conventions and feature specs. Install Agent OS before contributing — the workflow below depends on its slash commands inside Claude Code.
+
+[Install Agent OS →](https://buildermethods.com/agent-os/installation)
+
+### Step 1 — Inject relevant standards before writing any code
+
+`agent-os/standards/` contains the conventions for this codebase, indexed in `agent-os/standards/index.yml`. At the start of every task, run:
+
+```
+/inject-standards
+```
+
+Agent OS reads `index.yml`, analyses your current conversation context, and presents the relevant standards to confirm. You can also be explicit about which domain you need:
+
+```
+/inject-standards enrichment
+/inject-standards books
+/inject-standards enrichment books
+```
+
+| Changing… | Domain to inject |
+|---|---|
+| Enrichment pipeline (`src/enrichment.ts`) | `enrichment` |
+| Book map (`src/books.ts`) | `books` |
+| Config loading (`src/config.ts`) | `config` |
+| Test patterns | `testing` |
+
+Do not write code until the relevant standards are loaded. The standards contain constraints that are not obvious from the code and that the PR checklist will verify.
+
+### Step 2 — Plan significant features with a spec
+
+For anything beyond a small bug fix, create a spec before writing code. A spec captures scope, decisions, and the standards that apply — it is what reviewers read to understand *why* the code looks the way it does.
+
+1. In Claude Code, type `/plan` to activate plan mode.
+2. Run `/shape-spec`. It asks:
+   - **What are you building?** Describe the feature and paste the issue number.
+   - **Are there similar patterns in the codebase?** Point at files or features to reference.
+   - **Which standards apply?** Auto-suggested from `index.yml` — confirm or adjust.
+3. Agent OS builds a full implementation plan. Task 1 is always "save spec documentation" — the spec folder is written before any code is touched.
+4. Review the plan, then approve. Scope changes after approval must be reflected back in the spec.
+
+The spec is saved to:
+
+```
+agent-os/specs/YYYY-MM-DD-HHMM-short-description/
+├── plan.md        — full implementation plan
+├── shape.md       — scope, decisions, open questions
+├── references.md  — pointers to similar existing code
+└── standards.md   — full content of the relevant standards
+```
+
+Include the spec folder path in your PR description.
+
+### Standards vs skills
+
+`agent-os/standards/` files describe **conventions** (what to follow). `.claude/skills/` files describe **procedures** (owner-operated tasks such as cutting a release). Contributors do not create or modify skills.
+
+## Code conventions
+
+**TypeScript:**
+- ES Modules throughout — always use `.js` extensions in imports even though source files are `.ts`
+- Strict mode; target ES2022
+- No comments unless the *why* is non-obvious
+
+**Regex patterns:**
+- Every Bible reference regex must use a negative lookbehind for `[(` and a negative lookahead
+  for `]()` to prevent double-enriching already-linked text
+- Test any change to `BIBLE_REF_RE`, `SINGLE_CHAPTER_REF_RE`, or `BARE_CHAPTER_REF_RE` against:
+  `1 Samuel 16:1, 16:4-13`, `Matthew 2:1-6, 11-12`, `Jude 9-14`
+- The five enrichment passes in `enrichMarkdown()` are order-dependent and must not be reordered
+  — see `agent-os/standards/enrichment/three-pass-ordering`
+
+**Book map (`src/books.ts`):**
+- Keys in `BOOK_MAP` are lowercase — `lookupBook()` normalises input before lookup
+- All alternative names (e.g. `"ecclesiasticus"`, `"wisdom of ben sira"`) must map to the same
+  `BookInfo` as the canonical name
+- Set `singleChapter: true` only for books with exactly one chapter (Obadiah, Philemon, 2 John,
+  3 John, Jude) — this changes the Obsidian link format from `[[Abbrev-01#vN]]` to `[[Abbrev#vN]]`
+- See `agent-os/standards/books/` for full conventions
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Format
+
+```
+<type>[optional scope]: <short description>  ← 72 chars max, imperative mood
+
+[optional body]
+- What changed and why (one bullet per logical change)
+- Focus on the reason, not the mechanism — the diff shows the what
+
+[optional footer]
+Closes #<issue-number>
+BREAKING CHANGE: <description>  ← only if applicable
+```
+
+### Type reference
+
+| Type | When to use |
+|---|---|
+| `feat` | New capability visible to users (new book alias, new reference pattern) |
+| `fix` | Corrects wrong behaviour (regex mismatch, incorrect URL encoding) |
+| `docs` | README, CONTRIBUTING, inline comments only — no code change |
+| `refactor` | Code restructure with no behaviour change |
+| `test` | Add or fix tests only |
+| `chore` | Dependency bumps, build config, tooling |
+| `build` | Changes to the build system (`tsconfig`, `package.json` scripts) |
+| `ci` | GitHub Actions, CI config |
+
+### Full example
+
+```
+feat(books): add Tobit bare-chapter reference support
+
+- Extend BOOK_MAP entry for Tobit with singleChapter: false
+- Add Tobit to BARE_CHAPTER_REF_RE alternation group
+- Add test cases for Tobit 3, Tobit 12-14
+
+Tobit bare-chapter refs ("Tobit 3") were silently skipped because the
+book was missing from the chapter-only regex pass. Catholic study notes
+commonly cite entire chapters rather than individual verses.
+
+Closes #57
+```
+
+### Checklist before committing
+
+- [ ] Subject line is 72 characters or fewer and uses imperative mood ("add", not "added")
+- [ ] Body bullets explain *why* the change was made, not just *what* changed
+- [ ] Breaking changes marked with `!` after the type or `BREAKING CHANGE:` in the footer
+- [ ] Issue linked with `Closes #N` in the footer
+- [ ] `npm test` passes with no failures

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 # Bible Enrichment MCP Server - NRSVCE (New Revised Standard Version Catholic Edition)
 
-**Intelligent Markdown enrichment for Scripture and Catechism references**
+**Turns plain-text Bible references in your Markdown notes into Bible Gateway links and Obsidian wiki-links.**
 
+[![GitHub Release](https://img.shields.io/github/v/release/psenger/mcp-markdown-bible-enricher)](https://github.com/psenger/mcp-markdown-bible-enricher/releases)
 [![Catholic Bible](https://img.shields.io/badge/Catholic%20Bible-73%20books-green.svg)](https://github.com/psenger/mcp-markdown-bible-enricher#supported-books)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
@@ -11,78 +12,55 @@
 [![Model Context Protocol](https://img.shields.io/badge/MCP-1.12.1-purple)](https://modelcontextprotocol.io/)
 [![Obsidian](https://img.shields.io/badge/Obsidian-compatible-7c3aed)](https://obsidian.md)
 
-[Features](#features) • [Quick Start](#quick-start) • [Installation](#installation) • [Usage](#usage) • [Configuration](#configuration) • [API Reference](#api-reference)
+[Quick Start](#quick-start) • [Installation](#installation) • [Usage](#usage) • [Configuration](#configuration) • [Contributing](#contributing) • [Changelog](#changelog)
 
 </div>
 
 ---
 
-## Overview
-
-**Bible Enrichment MCP Server** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that automatically transforms plain-text Bible and Catechism references in your Markdown documents into linked references with Bible Gateway URLs and [Obsidian](https://obsidian.md) wiki-links.
-
-**Catholic Bible Resource:** This tool is designed for the Catholic Bible canon, supporting all **73 books** including the 7 deuterocanonical books:
-- **Tobit** - Righteousness and family
-- **Judith** - Courage and faith
-- **Wisdom** - Divine wisdom
-- **Sirach** (Ecclesiasticus) - Practical wisdom
-- **Baruch** - Prophecy and comfort
-- **1 Maccabees** - Jewish revolt history
-- **2 Maccabees** - Theological history
-
-These 7 books are included in Catholic Bibles but not in Protestant Bibles (which have 66 books). The default translation (NRSVCE) includes all deuterocanonical books.
-
-Perfect for:
-- Catholic theologians and researchers
-- Catholic content creators
-- [Obsidian](https://obsidian.md) vault builders
-- Catholic Bible study workflows
-
-### What It Does
+**Bible Enrichment MCP Server** is a [Model Context Protocol](https://modelcontextprotocol.io/) server that transforms plain-text Bible and Catechism references in your Markdown documents into linked references with [Bible Gateway](https://www.biblegateway.com/) URLs and [Obsidian](https://obsidian.md) wiki-links. It supports all **73 books of the Catholic Bible**, including the 7 deuterocanonical books absent from Protestant translations.
 
 Transform this:
+
 ```markdown
 Read CCC 528. Also see 1 Samuel 16:1, 16:4-13 and Matthew 2:6.
 ```
 
 Into this:
+
 ```markdown
-Read [CCC 528](https://www.catholiccrossreference.online/catechism/#!/search/528). Also see [1 Samuel 16:1, 16:4-13](https://www.biblegateway.com/passage/?search=1%20Samuel%2016%3A1%2C%2016%3A4-13&version=NRSVCE) ( [[1 Sam-16#v1]] , [[1 Sam-16#v4]] - [[1 Sam-16#v13]] ) and [Matthew 2:6](https://www.biblegateway.com/passage/?search=Matthew%202%3A6&version=NRSVCE) ( [[Matt-02#v6]] ).
+Read [CCC 528](https://www.catholiccrossreference.online/catechism/#!/search/528).
+Also see [1 Samuel 16:1, 16:4-13](https://www.biblegateway.com/passage/?search=1%20Samuel%2016%3A1%2C%2016%3A4-13&version=NRSVCE) ( [[1 Sam-16#v1]] , [[1 Sam-16#v4]] - [[1 Sam-16#v13]] )
+and [Matthew 2:6](https://www.biblegateway.com/passage/?search=Matthew%202%3A6&version=NRSVCE) ( [[Matt-02#v6]] ).
 ```
+
+Enrichment is **deterministic** — regex-based parsing with no LLM guessing involved in the transformation itself.
 
 ---
 
 ## Features
 
-- **Bible Gateway Links** — Every Scripture reference becomes a clickable link to Bible Gateway (NRSVCE translation by default)
-- **[Obsidian](https://obsidian.md) Wiki-Links** — Automatically generates `[[Book-Ch#vN]]` format for vault cross-referencing
-- **CCC Links** — Catechism of the Catholic Church references link directly to Catholic Cross Reference
-- **Deterministic Parsing** — Regex-based parsing (no LLM required)
-- **Pattern Recognition** — Recognizes complex patterns like `1 Samuel 16:1, 16:4-13` and `CCC 528-530, 610-612`
-- **Safe** — Won't modify existing links or break your Markdown structure
-- **Complete Catholic Bible** — Supports all 73 books including 7 deuterocanonical books
-- **Two Modes** — Process strings in memory or read/write files directly
+- **Bible Gateway links** — every Scripture reference becomes a clickable link (NRSVCE by default)
+- **Obsidian wiki-links** — generates `[[Book-Ch#vN]]` format for vault cross-referencing
+- **CCC links** — Catechism of the Catholic Church references link to Catholic Cross Reference
+- **Pattern recognition** — handles complex patterns like `1 Samuel 16:1, 16:4-13` and `CCC 528-530, 610-612`
+- **Idempotent** — already-linked references are skipped; safe to run the same document multiple times
+- **Complete Catholic Bible** — all 73 books including Tobit, Judith, Wisdom, Sirach, Baruch, 1-2 Maccabees
 
 ---
 
 ## Quick Start
 
 ```bash
-# Clone the repository
 git clone https://github.com/psenger/mcp-markdown-bible-enricher.git
 cd mcp-markdown-bible-enricher
-
-# Install dependencies
 npm install
-
-# Build the project
 npm run build
-
-# Test with MCP Inspector
 npm run inspect
 ```
 
-In the Inspector, try calling `bible_enrich_markdown` with:
+In the MCP Inspector, call `bible_enrich_markdown` with:
+
 ```
 Genesis 1:1 says "In the beginning..."
 ```
@@ -94,33 +72,16 @@ Genesis 1:1 says "In the beginning..."
 ### Prerequisites
 
 - Node.js >= 18.0.0
-- npm or yarn
 
-### Local Development Setup
+### Claude Desktop
 
-```bash
-# Install dependencies
-npm install
-
-# Build TypeScript
-npm run build
-
-# Watch mode for development
-npm run dev
-```
-
-### Integration with AI Tools
-
-#### Claude Desktop
-
-1. Locate your Claude Desktop config file:
+1. Locate your config file:
    - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
    - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
    - **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
-2. Add the server configuration:
+2. Add the server:
 
-**Basic configuration (uses defaults):**
 ```json
 {
   "mcpServers": {
@@ -132,7 +93,10 @@ npm run dev
 }
 ```
 
-**With custom Bible version and Obsidian format:**
+3. Restart Claude Desktop.
+
+To set a custom Bible version or Obsidian format, add `env` to the config:
+
 ```json
 {
   "mcpServers": {
@@ -148,16 +112,14 @@ npm run dev
 }
 ```
 
-3. Restart Claude Desktop
+### Claude Code CLI
 
-#### Claude Code CLI
-
-**Basic installation (project scope):**
 ```bash
 claude mcp add --transport stdio mcp-markdown-bible-enricher -- node /absolute/path/to/mcp-markdown-bible-enricher/dist/index.js
 ```
 
-**With environment variables:**
+With environment variables:
+
 ```bash
 claude mcp add --transport stdio \
   --env BIBLE_VERSION=NRSVCE \
@@ -165,21 +127,19 @@ claude mcp add --transport stdio \
   mcp-markdown-bible-enricher -- node /absolute/path/to/mcp-markdown-bible-enricher/dist/index.js
 ```
 
-**Scope options** (`--scope` flag):
-- `project` (default) — adds to `.mcp.json` in the current project directory
-- `user` — adds to your global `~/.claude.json` (available in all projects)
+Use `--scope user` to install globally across all projects:
 
 ```bash
-# Install globally for all projects
 claude mcp add --transport stdio --scope user mcp-markdown-bible-enricher -- node /absolute/path/to/mcp-markdown-bible-enricher/dist/index.js
 ```
 
-Verify installation:
+Verify:
+
 ```bash
 claude mcp list
 ```
 
-#### Cursor / VS Code with MCP Extension
+### Cursor / VS Code
 
 Add to `.cursor/mcp.json`:
 
@@ -196,102 +156,58 @@ Add to `.cursor/mcp.json`:
 
 ## Usage
 
-### Quick Example
+### Process text in a conversation
 
-**In Claude Desktop:**
 ```
 Use the bible_enrich_markdown tool to process this text:
 "According to Romans 8:28 and CCC 313, all things work together for good."
 ```
 
-**Result:**
+Result:
+
 ```markdown
 According to [Romans 8:28](https://www.biblegateway.com/passage/?search=Romans%208%3A28&version=NRSVCE) ( [[Rom-08#v28]] ) and [CCC 313](https://www.catholiccrossreference.online/catechism/#!/search/313), all things work together for good.
 ```
 
-**Example with Deuterocanonical Books:**
-```
-Use the bible_enrich_markdown tool to process this text:
-"Read Tobit 12:8 and Wisdom 3:1-4 for guidance."
-```
-
-**Result:**
-```markdown
-Read [Tobit 12:8](https://www.biblegateway.com/passage/?search=Tobit%2012%3A8&version=NRSVCE) ( [[Tob-12#v8]] ) and [Wisdom 3:1-4](https://www.biblegateway.com/passage/?search=Wisdom%203%3A1-4&version=NRSVCE) ( [[Wis-03#v1]] - [[Wis-03#v4]] ) for guidance.
-```
-
-### Two Ways to Use
-
-**Option 1: Process Text (Copy Result)**
-- Paste markdown into Claude conversation
-- Use `bible_enrich_markdown` tool
-- Copy enriched result and paste into your notes
-
-**Option 2: Process Files (Automatic Save)**
-- Use `bible_enrich_file` with a file path
-- File is enriched and saved automatically
-- Optionally specify different output path to keep original
+### Process a file directly
 
 ```
 Use bible_enrich_file with input_path: "/Users/me/Documents/bible-study.md"
 ```
 
-### Supported Reference Patterns
+The file is enriched in place. Supply `output_path` to write to a different location and keep the original.
 
-| Input Pattern         | Example                  | What It Recognizes                       |
-|-----------------------|--------------------------|------------------------------------------|
-| Single verse          | `John 3:16`              | One verse                                |
-| Verse range           | `Matthew 5:3-12`         | Consecutive verses                       |
-| Multiple verses       | `Psalm 23:1, 4, 6`       | Multiple individual verses               |
-| Chapter + ranges      | `1 Samuel 16:1, 16:4-13` | Mixed patterns                           |
-| Bare chapter          | `Isaiah 53`              | Entire chapter (no verse needed)         |
-| Single-chapter bare   | `Jude 9`                 | Verse in a single-chapter book           |
-| Single-chapter range  | `Jude 9-14`              | Verse range in a single-chapter book     |
-| CCC single            | `CCC 528`                | Single paragraph                         |
-| CCC range             | `CCC 528-530`            | Paragraph range                          |
-| CCC multiple          | `CCC 528-530, 610-612`   | Multiple ranges                          |
+### Supported reference patterns
+
+| Pattern | Example | What it matches |
+|---|---|---|
+| Single verse | `John 3:16` | One verse |
+| Verse range | `Matthew 5:3-12` | Consecutive verses |
+| Multiple verses | `Psalm 23:1, 4, 6` | Individual verses |
+| Chapter + ranges | `1 Samuel 16:1, 16:4-13` | Mixed chapter:verse patterns |
+| Bare chapter | `Isaiah 53` | Entire chapter |
+| Single-chapter book verse | `Jude 9` | Verse in a single-chapter book |
+| Single-chapter book range | `Jude 9-14` | Verse range in single-chapter book |
+| CCC single | `CCC 528` | Single paragraph |
+| CCC range | `CCC 528-530` | Paragraph range |
+| CCC multiple | `CCC 528-530, 610-612` | Multiple ranges |
 
 ---
 
 ## Configuration
 
-Customize the server via environment variables in your Claude Desktop config:
+All configuration is via environment variables, loaded once at server startup. Restart the MCP server after any change.
 
-### Environment Variables
+| Variable | Default | Description |
+|---|---|---|
+| `BIBLE_VERSION` | `NRSVCE` | Bible translation. NRSVCE and NABRE include deuterocanonical books; Protestant translations (ESV, NIV, KJV) do not. |
+| `OBSIDIAN_FORMAT` | `[[{abbrev}-{chapter2}#v{verse}]]` | Wiki-link template. Placeholders: `{abbrev}`, `{chapter}`, `{chapter2}` (zero-padded), `{verse}` |
+| `INCLUDE_OBSIDIAN_LINKS` | `true` | Set to `false` for Bible Gateway links only |
 
-| Variable                 | Default                            | Description                                                                                          |
-|--------------------------|------------------------------------|------------------------------------------------------------------------------------------------------|
-| `BIBLE_VERSION`          | `NRSVCE`                           | Bible translation (NRSVCE, NABRE, NCB, ESV, NIV, KJV, etc.) - NRSVCE includes deuterocanonical books |
-| `OBSIDIAN_FORMAT`        | `[[{abbrev}-{chapter2}#v{verse}]]` | Wiki-link template (placeholders: `{abbrev}`, `{chapter}`, `{chapter2}`, `{verse}`)                  |
-| `INCLUDE_OBSIDIAN_LINKS` | `true`                             | Include Obsidian links (`false` for Bible Gateway only)                                              |
+### Example configurations
 
-**Important:** Configuration changes require restarting the MCP server (fully quit and restart Claude Desktop).
+Bible Gateway links only, non-default translation:
 
-### Example Configurations
-
-**Different Bible version:**
-```json
-{
-  "mcpServers": {
-    "mcp-markdown-bible-enricher": {
-      "command": "node",
-      "args": ["/path/to/mcp-markdown-bible-enricher/dist/index.js"],
-      "env": {
-        "BIBLE_VERSION": "NRSVCE"
-      }
-    }
-  }
-}
-```
-
-**Custom Obsidian format:**
-```json
-"env": {
-  "OBSIDIAN_FORMAT": "[[Bible/{abbrev}/{chapter}#v{verse}]]"
-}
-```
-
-**Bible Gateway links only:**
 ```json
 "env": {
   "BIBLE_VERSION": "ESV",
@@ -299,88 +215,62 @@ Customize the server via environment variables in your Claude Desktop config:
 }
 ```
 
+Custom vault folder structure:
+
+```json
+"env": {
+  "OBSIDIAN_FORMAT": "[[Bible/{abbrev}/{chapter2}#v{verse}]]"
+}
+```
+
 ---
 
 ## API Reference
 
-### MCP Tools
+### Tools
 
 #### `bible_enrich_markdown`
 
 Enriches a Markdown string with Bible and CCC links.
 
-**Parameters:**
-- `markdown` (string, required) — The Markdown document to enrich
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `markdown` | string | yes | The Markdown content to enrich |
 
-**Returns:**
-- `string` — The enriched Markdown content
-
-**Example:**
-```json
-{
-  "markdown": "Read Isaiah 40:31 and CCC 2095 about hope."
-}
-```
+Returns the enriched Markdown string.
 
 #### `bible_enrich_file`
 
 Reads a Markdown file, enriches it, and writes the result.
 
-**Parameters:**
-- `input_path` (string, required) — Absolute path to the input Markdown file
-- `output_path` (string, optional) — Absolute path for the output file (defaults to overwriting input)
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `input_path` | string | yes | Absolute path to the input file |
+| `output_path` | string | no | Absolute path for output (defaults to overwriting input) |
 
-**Returns:**
-- `string` — Success message with output path
+Returns a success message with the output path.
 
-**Example:**
-```json
-{
-  "input_path": "/Users/me/notes.md",
-  "output_path": "/Users/me/notes-enriched.md"
-}
-```
-
-### MCP Prompts
+### Prompts
 
 #### `bible_enrich_document`
 
-A convenience prompt that instructs Claude to use the `bible_enrich_markdown` tool.
+A convenience prompt that instructs Claude to call `bible_enrich_markdown` on the supplied content.
 
-**Parameters:**
-- `markdown` (string, required) — The Markdown content to enrich
+| Parameter | Type | Required |
+|---|---|---|
+| `markdown` | string | yes |
 
 #### `help`
 
-Displays documentation for all available tools, configuration options, and usage examples.
-
-**Usage in Claude Desktop:**
-```
-Use the help prompt
-```
-
-Or simply:
-```
-help
-```
-
-This will show:
-- Available tools and their parameters
-- Configuration options (Bible versions, Obsidian formats)
-- Usage examples
-- Tips for better results
+Displays all available tools, configuration options, and usage examples. Call it with no arguments.
 
 ---
 
 ## Supported Books
 
-All **73 books of the Catholic Bible** are supported:
+All **73 books of the Catholic Bible** are supported.
 
-**Important:** To use deuterocanonical books (Tobit, Judith, Wisdom, Sirach, Baruch, 1-2 Maccabees), you must use a translation that includes them on Bible Gateway:
-- SUPPORTED: **NRSVCE** (New Revised Standard Version Catholic Edition) - **Default** - Includes all 73 books
-- SUPPORTED: **NABRE** (New American Bible Revised Edition) - Includes all 73 books
-- NOT SUPPORTED: **NCB** (New Catholic Bible) - Does NOT include deuterocanonical books on Bible Gateway
-- NOT SUPPORTED: Protestant translations (ESV, NIV, KJV, etc.) - Only 66 books
+**Translation note for deuterocanonical books** (Tobit, Judith, Wisdom, Sirach, Baruch, 1-2 Maccabees): these books are only available on Bible Gateway through Catholic translations. NRSVCE (default) and NABRE both include them. NCB and all Protestant translations do not.
 
 <details>
 <summary><b>Old Testament (46 books)</b></summary>
@@ -391,7 +281,7 @@ All **73 books of the Catholic Bible** are supported:
 - Wisdom: Job, Psalms, Proverbs, Ecclesiastes, Song of Solomon
 - Prophets: Isaiah, Jeremiah, Lamentations, Ezekiel, Daniel, Hosea, Joel, Amos, Obadiah, Jonah, Micah, Nahum, Habakkuk, Zephaniah, Haggai, Zechariah, Malachi
 
-**Deuterocanonical Books (7 books - Catholic only):**
+**Deuterocanonical (7 books — Catholic only):**
 - Historical: Tobit, Judith, 1-2 Maccabees
 - Wisdom: Wisdom, Sirach (Ecclesiasticus)
 - Prophetic: Baruch
@@ -409,110 +299,35 @@ All **73 books of the Catholic Bible** are supported:
 
 </details>
 
-### Obsidian Abbreviations
-
 <details>
-<summary><b>Complete list of all 73 book abbreviations</b></summary>
+<summary><b>Complete abbreviation list (all 73 books)</b></summary>
 
 **Old Testament (46 books):**
 
-Pentateuch:
-- Genesis → `Gen`
-- Exodus → `Exod`
-- Leviticus → `Lev`
-- Numbers → `Num`
-- Deuteronomy → `Deut`
+Pentateuch: Genesis → `Gen`, Exodus → `Exod`, Leviticus → `Lev`, Numbers → `Num`, Deuteronomy → `Deut`
 
-Historical Books:
-- Joshua → `Josh`
-- Judges → `Judg`
-- Ruth → `Ruth`
-- 1 Samuel → `1 Sam`
-- 2 Samuel → `2 Sam`
-- 1 Kings → `1 Kings`
-- 2 Kings → `2 Kings`
-- 1 Chronicles → `1 Chron`
-- 2 Chronicles → `2 Chron`
-- Ezra → `Ezr`
-- Nehemiah → `Neh`
-- Tobit → `Tob` (deuterocanonical)
-- Judith → `Jdt` (deuterocanonical)
-- Esther → `Esth`
-- 1 Maccabees → `1 Macc` (deuterocanonical)
-- 2 Maccabees → `2 Macc` (deuterocanonical)
+Historical: Joshua → `Josh`, Judges → `Judg`, Ruth → `Ruth`, 1 Samuel → `1 Sam`, 2 Samuel → `2 Sam`, 1 Kings → `1 Kings`, 2 Kings → `2 Kings`, 1 Chronicles → `1 Chron`, 2 Chronicles → `2 Chron`, Ezra → `Ezr`, Nehemiah → `Neh`, Tobit → `Tob`*, Judith → `Jdt`*, Esther → `Esth`, 1 Maccabees → `1 Macc`*, 2 Maccabees → `2 Macc`*
 
-Wisdom Books:
-- Job → `Job`
-- Psalms → `Ps`
-- Proverbs → `Prov`
-- Ecclesiastes → `Eccles`
-- Song of Solomon → `Song`
-- Wisdom → `Wis` (deuterocanonical)
-- Sirach → `Sir` (deuterocanonical, also called Ecclesiasticus)
+Wisdom: Job → `Job`, Psalms → `Ps`, Proverbs → `Prov`, Ecclesiastes → `Eccles`, Song of Solomon → `Song`, Wisdom → `Wis`*, Sirach → `Sir`*
 
-Prophetic Books:
-- Isaiah → `Isa`
-- Jeremiah → `Jer`
-- Lamentations → `Lam`
-- Baruch → `Bar` (deuterocanonical)
-- Ezekiel → `Ezek`
-- Daniel → `Dan`
-- Hosea → `Hos`
-- Joel → `Joel`
-- Amos → `Am`
-- Obadiah → `Obad` (single chapter)
-- Jonah → `Jonah`
-- Micah → `Micah`
-- Nahum → `Nah`
-- Habakkuk → `Hab`
-- Zephaniah → `Zeph`
-- Haggai → `Hag`
-- Zechariah → `Zech`
-- Malachi → `Mal`
+Prophetic: Isaiah → `Isa`, Jeremiah → `Jer`, Lamentations → `Lam`, Baruch → `Bar`*, Ezekiel → `Ezek`, Daniel → `Dan`, Hosea → `Hos`, Joel → `Joel`, Amos → `Am`, Obadiah → `Obad`†, Jonah → `Jonah`, Micah → `Micah`, Nahum → `Nah`, Habakkuk → `Hab`, Zephaniah → `Zeph`, Haggai → `Hag`, Zechariah → `Zech`, Malachi → `Mal`
 
 **New Testament (27 books):**
 
-Gospels:
-- Matthew → `Matt`
-- Mark → `Mark`
-- Luke → `Luke`
-- John → `John`
+Gospels: Matthew → `Matt`, Mark → `Mark`, Luke → `Luke`, John → `John`
 
-History:
-- Acts → `Acts`
+History: Acts → `Acts`
 
-Pauline Epistles:
-- Romans → `Rom`
-- 1 Corinthians → `1 Cor`
-- 2 Corinthians → `2 Cor`
-- Galatians → `Gal`
-- Ephesians → `Ephes`
-- Philippians → `Phil`
-- Colossians → `Col`
-- 1 Thessalonians → `1 Thess`
-- 2 Thessalonians → `2 Thess`
-- 1 Timothy → `1 Tim`
-- 2 Timothy → `2 Tim`
-- Titus → `Titus`
-- Philemon → `Philem` (single chapter)
+Pauline Epistles: Romans → `Rom`, 1 Corinthians → `1 Cor`, 2 Corinthians → `2 Cor`, Galatians → `Gal`, Ephesians → `Ephes`, Philippians → `Phil`, Colossians → `Col`, 1 Thessalonians → `1 Thess`, 2 Thessalonians → `2 Thess`, 1 Timothy → `1 Tim`, 2 Timothy → `2 Tim`, Titus → `Titus`, Philemon → `Philem`†
 
-General Epistles:
-- Hebrews → `Heb`
-- James → `James`
-- 1 Peter → `1 Pet`
-- 2 Peter → `2 Pet`
-- 1 John → `1 John`
-- 2 John → `2 John` (single chapter)
-- 3 John → `3 John` (single chapter)
-- Jude → `Jude` (single chapter)
+General Epistles: Hebrews → `Heb`, James → `James`, 1 Peter → `1 Pet`, 2 Peter → `2 Pet`, 1 John → `1 John`, 2 John → `2 John`†, 3 John → `3 John`†, Jude → `Jude`†
 
-Apocalypse:
-- Revelation → `Rev`
+Apocalypse: Revelation → `Rev`
 
-**Notes:**
-- Single-chapter books (Obadiah, Philemon, 2 John, 3 John, Jude) support both forms: "Jude 1:9" and "Jude 9"
-- Alternative names: Song of Solomon = Song of Songs, Sirach = Ecclesiasticus = Wisdom of Ben Sira
-- All deuterocanonical books marked above
+`*` deuterocanonical — requires NRSVCE or NABRE translation  
+`†` single-chapter book — supports both `Jude 1:9` and `Jude 9` forms
+
+Alternative names: Song of Solomon = Song of Songs; Sirach = Ecclesiasticus = Wisdom of Ben Sira
 
 </details>
 
@@ -520,75 +335,35 @@ Apocalypse:
 
 ## How It Works
 
-### Architecture
+The enrichment function processes Markdown in five sequential regex passes:
 
-The enrichment process uses **five sequential regex passes**:
+1. **Backtick unwrapping** — removes backticks around references like `` `1 Samuel 16:1:` `` before processing
+2. **Bible references** — matches `chapter:verse` patterns not already inside Markdown links
+3. **Single-chapter bare verse** — matches bare verse citations in single-chapter books (e.g., `Jude 9`)
+4. **Bare chapter** — matches chapter-only citations (e.g., `Isaiah 53`)
+5. **CCC references** — matches Catechism paragraph numbers
 
-1. **Backtick Unwrapping** — Detects references like `` `1 Samuel 16:1:` `` and removes backticks before processing
-2. **Bible Reference Detection** — Matches plain-text `chapter:verse` Scripture references (skips existing Markdown links)
-3. **Single-Chapter Bare Verse** — Matches bare verse citations in single-chapter books (e.g., `Jude 9`, `Obadiah 21`)
-4. **Bare Chapter References** — Matches chapter-only citations (e.g., `Isaiah 53`, `Psalm 91`)
-5. **CCC Reference Detection** — Matches Catechism paragraph numbers
+**Key implementation details:**
+- Negative lookbehind/lookahead prevents double-enriching already-linked text
+- Implicit chapter inheritance: `16:1, 4-13` uses chapter 16 for both groups
+- Single-chapter books use a different Obsidian link format (`[[Jude#v9]]` rather than `[[Jude-01#v9]]`)
+- YAML front matter is stripped before enrichment and reattached unchanged
 
-### Parsing Strategy
+### Output format
 
-```mermaid
-graph LR
-    A[Input Markdown] --> B[Unwrap Backticks]
-    B --> C[Match chapter:verse Refs]
-    C --> D[Match Single-Chapter Bare Verse]
-    D --> E[Match Bare Chapter Refs]
-    E --> F[Match CCC Refs]
-    F --> G[Output Enriched]
-```
-
-**Key Features:**
-- Negative lookbehind/lookahead prevents double-linking
-- Handles implicit chapter repetition (`16:1, 4-13` → chapter 16 for both)
-- Parses verse ranges (`3-12`) and comma-separated lists (`1, 4, 6`)
-- Special formatting for single-chapter books
-
-### Bible Gateway URLs
-
-Format: `https://www.biblegateway.com/passage/?search={reference}&version=NRSVCE`
-- Translation: New Revised Standard Version Catholic Edition (NRSVCE) by default
-- NRSVCE includes all 73 Catholic Bible books (deuterocanonical books included)
-- URL encoding handles spaces and special characters
-- Configurable via `BIBLE_VERSION` environment variable
-
-### [Obsidian](https://obsidian.md) Wiki-Links
-
-Format: `[[Book-Ch#vN]]`
-- Example: `[[Matt-05#v3]]` for Matthew 5:3
-- Single-chapter books: `[[Jude#v9]]` for Jude 9 (no chapter number in link)
-- Bare chapters: `[[Isa-53]]` for Isaiah 53 (no verse anchor)
-- Configurable via `OBSIDIAN_FORMAT` environment variable
-
-### CCC Links
-
-Format: `https://www.catholiccrossreference.online/catechism/#!/search/{numbers}`
-- Supports ranges: `528-530`
-- Supports lists: `528, 530, 532`
+| Reference | Bible Gateway link | Obsidian wiki-link |
+|---|---|---|
+| `John 3:16` | `[John 3:16](https://www.biblegateway.com/...)` | `[[John-03#v16]]` |
+| `Matthew 5:3-12` | `[Matthew 5:3-12](https://www.biblegateway.com/...)` | `[[Matt-05#v3]] - [[Matt-05#v12]]` |
+| `Jude 9` | `[Jude 9](https://www.biblegateway.com/...)` | `[[Jude#v9]]` |
+| `Isaiah 53` | `[Isaiah 53](https://www.biblegateway.com/...)` | `[[Isa-53]]` |
+| `CCC 528` | `[CCC 528](https://www.catholiccrossreference.online/...)` | *(none)* |
 
 ---
 
 ## Obsidian Integration
 
-This server is designed to work seamlessly with [Obsidian](https://obsidian.md) vaults. Bible references are enriched with wiki-links that match Obsidian's `[[Note#heading]]` linking convention.
-
-### Default Wiki-Link Format
-
-| Reference Type | Input | Obsidian Wiki-Link |
-|---|---|---|
-| Verse | `John 3:16` | `[[John-03#v16]]` |
-| Verse range | `Matthew 5:3-12` | `[[Matt-05#v3]] - [[Matt-05#v12]]` |
-| Single-chapter book | `Jude 9` | `[[Jude#v9]]` |
-| Single-chapter range | `Jude 9-14` | `[[Jude#v9]] - [[Jude#v14]]` |
-| Bare chapter | `Isaiah 53` | `[[Isa-53]]` |
-
-### Custom Vault Structures
-
-If your vault uses a different file-naming convention, set `OBSIDIAN_FORMAT` to match:
+Bible references are enriched with wiki-links matching Obsidian's `[[Note#heading]]` convention. If your vault uses a different file-naming structure, set `OBSIDIAN_FORMAT` to match:
 
 ```bash
 # Flat structure: "Gen 1:1" → [[Gen 1#v1]]
@@ -601,174 +376,156 @@ OBSIDIAN_FORMAT="[[Bible/{abbrev}/{chapter2}#v{verse}]]"
 OBSIDIAN_FORMAT="[[{abbrev}-{chapter2}#verse-{verse}]]"
 ```
 
-**Available placeholders:**
-- `{abbrev}` — book abbreviation (e.g., `Gen`, `1 Sam`, `Matt`)
-- `{chapter}` — chapter number (e.g., `1`, `16`)
-- `{chapter2}` — zero-padded chapter number (e.g., `01`, `16`)
-- `{verse}` — verse number (e.g., `1`, `28`)
+Available placeholders: `{abbrev}`, `{chapter}`, `{chapter2}` (zero-padded), `{verse}`.
 
 ---
 
-## Error Handling
+## Agentic Usage
 
-### Invalid Book Names
-References to non-existent books (e.g., "Book of Mormon 1:1") are **left unchanged**. The tool only enriches recognized Bible book names.
+This server is built to work with agentic workflows. Claude Code, Claude Desktop, and other MCP clients can call the tools directly from within a conversation.
 
-### Invalid Chapter/Verse References
-Invalid chapter or verse numbers (e.g., "Genesis 999:999") are **processed but may produce broken Bible Gateway links**. Bible Gateway will show an error page for invalid references.
+### Calling tools from Claude Code
 
-### File Errors
-- **File not found**: Returns error message: `Error: ENOENT: no such file or directory`
-- **Permission denied**: Returns error message: `Error: EACCES: permission denied`
-- **Invalid encoding**: Non-UTF-8 files may produce garbled output or errors
+Once the server is registered, Claude Code picks up the tools automatically. You can instruct it directly:
 
-### Tool Errors
-All tool errors are caught and returned with `isError: true` flag. Error messages are user-friendly and indicate the problem.
+```
+Use bible_enrich_file with input_path: "/Users/me/vault/notes/week-1.md"
+```
+
+Or use the built-in `bible_enrich_document` prompt for interactive enrichment of text you paste in.
+
+### agent-os/ directory
+
+The `agent-os/` directory contains machine-readable specs and standards that help AI agents work with this codebase consistently across sessions.
+
+```
+agent-os/
+├── specs/           # Change-specific specs (one per feature/fix)
+│   ├── 2026-03-18-1600-single-chapter-bare-verse-refs
+│   ├── 2026-03-18-1700-bare-chapter-refs
+│   └── 2026-03-19-0900-frontmatter-protection
+└── standards/       # Durable conventions for the codebase
+    ├── index.yml    # Index of all standards with descriptions
+    ├── books/       # BOOK_MAP key casing, abbreviation sources, alternative names
+    ├── config/      # Config loading lifecycle, opt-out patterns
+    ├── enrichment/  # Regex pass ordering, lookbehind guards, chapter inheritance
+    ├── global/      # Cross-cutting principles (DRY, SOLID, TDD, etc.)
+    └── testing/     # Jest config module cache limitations
+```
+
+When proposing changes to the codebase, consult the relevant standard in `agent-os/standards/` before writing code. The `enrichment/three-pass-ordering` standard, for example, explains why the regex pass order is fixed and must not change.
+
+### CLAUDE.md
+
+`CLAUDE.md` at the project root provides Claude Code with project-specific guidance: TypeScript conventions, regex testing requirements, import extension rules, and the book-mapping schema. It is loaded automatically by Claude Code at the start of each session.
+
+---
+
+## Error handling
+
+| Scenario | Behaviour |
+|---|---|
+| Unrecognised book name | Reference is left unchanged |
+| Invalid chapter/verse numbers | Enriched, but the resulting Bible Gateway link may 404 |
+| File not found | Returns `Error: ENOENT: no such file or directory` |
+| Permission denied | Returns `Error: EACCES: permission denied` |
+
+All tool errors are returned with `isError: true` and a user-readable message.
 
 ---
 
 ## Limitations
 
-### File Size
-- Files are loaded entirely into memory
-- **Recommended limit**: < 10MB
-- Large files (>10MB) may cause performance issues or memory errors
-
-### Character Encoding
-- **Required**: UTF-8 encoding
-- Non-UTF-8 files will produce incorrect output or errors
-- **No automatic encoding detection**
-
-### Pattern Recognition
-- Uses regex for pattern matching
-- Very complex nested structures may not be detected
-- References inside code blocks (triple backticks) are still enriched
-- References inside inline code (single backticks) are unwrapped and enriched
-- **CCC requires space**: Use "CCC 528", not "CCC528"
-- Single-chapter books (Obadiah, Philemon, 2 John, 3 John, Jude) support both `Jude 1:9` and `Jude 9` forms
-- Bare chapter references like `Isaiah 53` and `Psalm 91` are supported without a verse number
-
-### Bible Gateway Limitations
-- Links depend on Bible Gateway's URL structure
-- Not all Bible translations are available on Bible Gateway
-- **Deuterocanonical books**: Only available in Catholic translations (NRSVCE, NABRE)
-- **NCB**: Does NOT include deuterocanonical books despite being "Catholic"
-
-### Configuration
-- Configuration is loaded **once at startup**
-- Changing environment variables requires **restarting the MCP server**
-- No runtime configuration changes supported
+- **File size** — files are loaded entirely into memory; keep inputs under 10 MB
+- **Encoding** — UTF-8 only; non-UTF-8 input produces incorrect output
+- **Code blocks** — triple-backtick blocks are still enriched; only inline single-backtick references are unwrapped then enriched
+- **CCC format** — requires a space: `CCC 528`, not `CCC528`
+- **Configuration** — loaded once at startup; restart the server after changing env vars
+- **Deuterocanonical on Bible Gateway** — NRSVCE and NABRE only; NCB and Protestant translations lack these books
 
 ---
- 
+
 ## Development
 
-### Project Structure
+### Project structure
 
 ```
 mcp-markdown-bible-enricher/
 ├── src/
-│   ├── __tests__/       # tests
-│   ├── config.ts        # Configuration for Bible Enrichment MCP Server
-│   ├── index.ts         # MCP server entry point
-│   ├── enrichment.ts    # Core regex logic
-│   └── books.ts         # Bible book mappings
-├── dist/                # Compiled JavaScript (generated)
-├── package.json
-├── tsconfig.json
-├── CLAUDE.md           # Claude Code guidance
-└── README.md
+│   ├── __tests__/    # unit tests
+│   ├── config.ts     # env var loading
+│   ├── index.ts      # MCP server entry point
+│   ├── enrichment.ts # core regex logic
+│   └── books.ts      # Bible book → abbreviation map
+├── agent-os/         # agentic specs and standards
+├── dist/             # compiled output (generated)
+├── CLAUDE.md         # Claude Code project guidance
+├── CONTRIBUTING.md   # contributor guide
+├── CHANGELOG.md      # release history
+└── package.json
 ```
 
-### Available Scripts
+### Scripts
 
 ```bash
-npm run build         # Compile TypeScript
-npm run start         # Run the server
-npm run dev           # Watch mode (auto-rebuild)
-npm run inspect       # MCP Inspector GUI
-npm run test          # Run tests
-npm run test:watch    # Run tests in watch mode
-npm run test:coverage # Run tests with coverage
-npm run lint          # Lint with ESLint
-npm run format        # Format with Prettier
-npm run format:check  # Check formatting
-npm run clean         # Remove dist/
+npm run build           # compile TypeScript
+npm run start           # run the compiled server
+npm run dev             # watch mode (tsx)
+npm run inspect         # MCP Inspector browser GUI
+npm test                # run tests
+npm run test:watch      # watch mode
+npm run test:coverage   # coverage report
+npm run lint            # ESLint
+npm run format          # Prettier
+npm run format:check    # check formatting without writing
+npm run clean           # remove dist/
 ```
 
-### Testing
+### TypeScript notes
 
-**Unit Tests (Jest):**
-```bash
-npm test                 # Run all tests
-npm run test:watch       # Watch mode
-npm run test:coverage    # Coverage report
-```
+- Module system: ES Modules (`"type": "module"`)
+- Import extensions: always use `.js` in imports even though source files are `.ts` — required for Node16 module resolution
+- Target: ES2022, strict mode enabled
 
-**Test coverage:** 73 Catholic Bible books, configuration, enrichment patterns, edge cases
+### Adding a new Bible book or alias
 
-**Interactive Testing (MCP Inspector):**
-```bash
-npm run inspect
-```
-
-Opens browser GUI for:
-- Testing tools with custom inputs
-- Inspecting server capabilities
-- Real-time debugging
-
-### TypeScript Configuration
-
-- **Module System**: ES Modules (`"type": "module"`)
-- **Import Extensions**: Use `.js` in imports even though files are `.ts`
-- **Target**: ES2022
-- **Strict Mode**: Enabled
+See `agent-os/standards/books/` for the book-map conventions and `src/books.ts` for the implementation. The key rules are in `BOOK_MAP` key casing and the `singleChapter` flag.
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
-
 <details>
 <summary><b>Server not appearing in Claude Desktop</b></summary>
 
-1. Verify the path in `claude_desktop_config.json` is absolute
-2. Ensure the build succeeded: `npm run build`
-3. Check the MCP logs (Help → Developer Tools in Claude Desktop)
-4. Restart Claude Desktop
+1. Verify the path in `claude_desktop_config.json` is an absolute path
+2. Confirm the build succeeded: `npm run build`
+3. Check MCP logs via Help → Developer Tools in Claude Desktop
+4. Fully quit and restart Claude Desktop
 
 </details>
 
 <details>
 <summary><b>References not being detected</b></summary>
 
-- Ensure book names are spelled correctly (case-insensitive)
-- Check for typos in chapter:verse format (must be `chapter:verse`)
-- Verify references aren't already inside Markdown links `[text](url)`
-- For deuterocanonical books, ensure you're using a Catholic translation (NRSVCE or NABRE)
-- Use backticks for ambiguous cases: `` `John 3:16` ``
+- Book names are case-insensitive but must be spelled correctly
+- Format must be `Book chapter:verse` — confirm there is no extra punctuation
+- References already inside Markdown links `[text](url)` are skipped intentionally
+- For deuterocanonical books, confirm you are using NRSVCE or NABRE
 
 </details>
 
 <details>
 <summary><b>Deuterocanonical books not working</b></summary>
 
-If references to Tobit, Judith, Wisdom, Sirach, Baruch, or Maccabees aren't working:
+Set `BIBLE_VERSION` to `NRSVCE` (default) or `NABRE`. NCB does not include these books on Bible Gateway despite being a Catholic translation. Protestant translations (ESV, NIV, KJV) also lack them.
 
-1. **Check your Bible version**: NCB does NOT include deuterocanonical books
-   ```json
-   "env": {
-     "BIBLE_VERSION": "NRSVCE"
-   }
-   ```
+</details>
 
-2. **Verify translation on Bible Gateway**: Visit Bible Gateway and manually search for "Tobit 1:1" with your chosen translation
+<details>
+<summary><b>Configuration changes not taking effect</b></summary>
 
-3. **Supported translations for deuterocanonical books**:
-   - SUPPORTED: NRSVCE (default)
-   - SUPPORTED: NABRE
-   - NOT SUPPORTED: NCB, ESV, NIV, KJV (Protestant translations)
+Configuration is loaded once at startup. After editing env vars: save the config file, **fully quit** Claude Desktop, then restart it.
 
 </details>
 
@@ -776,10 +533,7 @@ If references to Tobit, Judith, Wisdom, Sirach, Baruch, or Maccabees aren't work
 <summary><b>File permission or encoding errors</b></summary>
 
 ```bash
-# Check file permissions
-ls -l /path/to/file.md
-
-# Check file encoding
+# Check encoding
 file -I /path/to/file.md
 
 # Convert to UTF-8 if needed
@@ -789,72 +543,58 @@ iconv -f ISO-8859-1 -t UTF-8 input.md > output.md
 </details>
 
 <details>
-<summary><b>Configuration changes not taking effect</b></summary>
-
-Configuration is loaded **once at startup**. After changing environment variables in Claude Desktop config:
-
-1. Save the config file
-2. **Fully quit** Claude Desktop (not just close window)
-3. Restart Claude Desktop
-4. Test with: `Use the help prompt` to verify configuration
-
-</details>
-
-<details>
 <summary><b>Build errors</b></summary>
 
 ```bash
-# Clear node_modules and reinstall
 rm -rf node_modules package-lock.json
 npm install
-
-# Clean and rebuild
 npm run clean
 npm run build
 ```
 
 </details>
 
-### Getting Help
+---
 
-- Check the [API Reference](#api-reference)
-- [Open a discussion](https://github.com/psenger/mcp-markdown-bible-enricher/discussions)
-- [Report a bug](https://github.com/psenger/mcp-markdown-bible-enricher/issues)
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for:
+
+- Development setup and local testing
+- Regex pattern conventions and testing requirements
+- How to add new Bible books or aliases
+- Commit message and PR conventions (Conventional Commits)
+- How to use `agent-os/` specs when proposing changes
+
+To report a bug or request a feature, [open an issue](https://github.com/psenger/mcp-markdown-bible-enricher/issues).
+
+---
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for the full release history. This project follows [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
 ## License
 
-This project is licensed under the **GNU General Public License v3.0**.
-
-See the [LICENSE](LICENSE) file for full details, or visit [https://www.gnu.org/licenses/gpl-3.0.html](https://www.gnu.org/licenses/gpl-3.0.html).
+Licensed under the **GNU General Public License v3.0**. See [LICENSE](./LICENSE) for full details.
 
 ---
 
 ## Acknowledgments
 
-- **Model Context Protocol** — [Anthropic's MCP SDK](https://github.com/anthropics/modelcontextprotocol)
-- **Bible Gateway** — Scripture text and linking
-- **Catholic Cross Reference** — Catechism paragraph linking
-- **[Obsidian](https://obsidian.md) Community** — Inspiration for wiki-link format ([Obsidian Community Plugins](https://obsidian.md/plugins))
-
----
-
-## Support
-
-If this project helps your work:
-
-- Star the repository
-- Report bugs and suggest features
-- Contribute code or documentation
-- Share with others who might benefit
+- [Anthropic MCP SDK](https://github.com/anthropics/modelcontextprotocol) — Model Context Protocol implementation
+- [Bible Gateway](https://www.biblegateway.com/) — Scripture text and passage linking
+- [Catholic Cross Reference](https://www.catholiccrossreference.online/) — Catechism paragraph linking
+- [Obsidian](https://obsidian.md) — wiki-link format inspiration
 
 ---
 
 <div align="center">
 
-**Built for Catholic Bible study and research**
+**Built for Catholic Bible study and agentic Markdown workflows**
 
-[Report Bug](https://github.com/psenger/mcp-markdown-bible-enricher/issues) • [Request Feature](https://github.com/psenger/mcp-markdown-bible-enricher/issues) • [Documentation](https://github.com/psenger/mcp-markdown-bible-enricher#readme)
+[Report Bug](https://github.com/psenger/mcp-markdown-bible-enricher/issues) • [Request Feature](https://github.com/psenger/mcp-markdown-bible-enricher/issues) • [Security](./SECURITY.md)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes.
+
+| Version | Supported |
+|---|---|
+| Latest release | ✓ |
+| Older releases | ✗ |
+
+## Reporting a Vulnerability
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+Use GitHub's private vulnerability reporting: go to the [Security tab](https://github.com/psenger/mcp-markdown-bible-enricher/security) and click **Report a vulnerability**. This keeps the details private until a fix is available.
+
+Include:
+
+- A clear description of the vulnerability and its potential impact
+- Steps to reproduce, including any crafted input that triggers the issue
+- The server version you tested (`version` field in `package.json`)
+- Your Node.js version (`node --version`)
+
+**Expected response time:** acknowledgement within 5 business days; resolution or status update within 30 days, depending on complexity.
+
+## Scope
+
+This server runs locally over stdio. It processes Markdown text, generates URL strings, and reads/writes local files on behalf of the MCP client. It does not authenticate users, open network listeners, or transmit file content to external services.
+
+**In scope:**
+
+- **ReDoS** — crafted input that causes catastrophic backtracking in the enrichment regex passes
+- **Path traversal** — `bible_enrich_file` writing outside directories the caller intends
+- **Dependency CVEs** — known vulnerabilities in direct runtime dependencies (`package.json` `dependencies`)
+
+**Out of scope:**
+
+- Content or availability of third-party services (Bible Gateway, Catholic Cross Reference)
+- Security of MCP clients (Claude Desktop, Claude Code, Cursor) — report those upstream
+- Vulnerabilities in dev-only dependencies (`devDependencies`) that cannot be triggered at runtime
+- General bugs without a security impact — [open a bug report](https://github.com/psenger/mcp-markdown-bible-enricher/issues/new?template=bug_report.md) instead
+
+## Disclosure Policy
+
+Once a fix is ready and released:
+
+1. A patch release is cut and tagged
+2. The vulnerability is documented in `CHANGELOG.md` under **Security**
+3. A GitHub Security Advisory is published referencing the fixed version

--- a/package.json
+++ b/package.json
@@ -80,9 +80,5 @@
   "bugs": {
     "url": "https://github.com/psenger/mcp-markdown-bible-enricher/issues"
   },
-  "homepage": "https://github.com/psenger/mcp-markdown-bible-enricher#readme",
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/psenger"
-  }
+  "homepage": "https://github.com/psenger/mcp-markdown-bible-enricher#readme"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { createRequire } from "node:module";
 import { enrichMarkdown } from "./enrichment.js";
+
+const _require = createRequire(import.meta.url);
+const { version: SERVER_VERSION } = _require("../package.json") as { version: string };
 
 // ──────────────────────────────────────────────────────────────
 // Server
@@ -9,7 +13,7 @@ import { enrichMarkdown } from "./enrichment.js";
 
 const server = new McpServer({
   name: "mcp-markdown-bible-enricher",
-  version: "0.0.1",
+  version: SERVER_VERSION,
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -131,7 +135,7 @@ server.prompt(
         role: "user",
         content: {
           type: "text",
-          text: `Bible Enrichment MCP Server v0.0.1
+          text: `Bible Enrichment MCP Server v${SERVER_VERSION}
 
 Available Bible Enrichment Tools:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Linked issue

Closes #29

## What changed and why

This project had no standard open-source scaffolding or agentic workflow support. Contributors and agentic tools (Claude Code, MCP clients) had no structured entry points for onboarding, contributing, or operating the release pipeline. This PR brings the project up to a fully agentic, well-documented standard.

- **CHANGELOG.md** — bootstrapped in Keep a Changelog v1.1.0 format with backfilled history and comparison links
- **CONTRIBUTING.md** — dev setup, conventions, regex guidelines, book map guidance, Conventional Commits format, and Agent OS workflow (`/inject-standards`, `/shape-spec`)
- **SECURITY.md** — vulnerability reporting instructions (private, not public issues)
- **GitHub templates** — bug report, feature request, and PR template added under `.github/`
- **Claude skills** — four owner-operated slash commands added under `.claude/skills/`:
  - `/start-work-on-an-issue` — checks out main, derives a typed branch, assigns the issue
  - `/changelog` — collects commits since last tag and writes a versioned CHANGELOG entry
  - `/start-a-release` — cuts a release branch, bumps `package.json`, runs `/changelog`, opens a PR
  - `/complete-a-release` — tags the release and creates the GitHub release after the PR merges
- **CLAUDE.md** — updated with a skills reference table and branch naming convention
- **`.gitignore`** — now tracks `.claude/skills/`, ignores `.claude/settings.local.json`, stops ignoring `CLAUDE.md`
- **`src/index.ts`** — server version now read dynamically from `package.json` instead of hardcoded `"0.0.1"`
- **`tsconfig.json`** — added `resolveJsonModule: true` to support the JSON import above
- **`package.json`** — removed `funding` field

## Test plan

This PR adds documentation, templates, and skills — no enrichment logic was changed. The only code change is the dynamic version read in `src/index.ts`.

**Input:** `npm test` before and after the change.

**Output:** All tests pass with no failures. The version string in the MCP server and help prompt now reflects `package.json` correctly.

## Checklist

- [x] `npm test` passes with no failures
- [x] New or changed regex patterns tested against complex multi-verse references
- [x] If a new book or alias was added, `BOOK_MAP` key is lowercase and `lookupBook()` resolves it correctly
- [x] If the enrichment pipeline changed, pass ordering was not altered without updating `agent-os/standards/enrichment/three-pass-ordering`
- [x] Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)

---

*PR review and merge is handled by the maintainer. Please do not merge your own PR.*