### PR TITLE
chore: bump fast-uri 3.1.0 → 3.1.2 to patch CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3872,9 +3872,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Linked issue

Closes #31

## What changed and why

Cherry-picks the Dependabot commit from #28 onto the current `main` (which had moved forward since that PR was opened). Bumps the transitive dependency `fast-uri` from 3.1.0 to 3.1.2 in `package-lock.json`.

Two high-severity CVEs are resolved by this single bump:

| CVE | Advisory | Summary | Fixed in |
|---|---|---|---|
| CVE-2026-6321 | GHSA-q3j6-qgpj-74h6 | Path traversal via percent-encoded dot segments | 3.1.1 |
| CVE-2026-6322 | GHSA-v39h-62p7-jpjc | Host confusion via percent-encoded authority delimiters | 3.1.2 |

## Test plan

- `npm audit` — no remaining `fast-uri` advisories (one unrelated `brace-expansion` moderate remains, pre-existing)
- `npm test` — 130/130 tests pass
- `npm run build` — compiles cleanly

## Checklist

- [x] Closes a tracked issue
- [x] `npm audit` shows no `fast-uri` vulnerabilities
- [x] All tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] No functional code changes — lockfile only